### PR TITLE
Improve challenge back-end operation

### DIFF
--- a/src/GRA.Data/Repository/ChallengeRepository.cs
+++ b/src/GRA.Data/Repository/ChallengeRepository.cs
@@ -17,7 +17,8 @@ namespace GRA.Data.Repository
         {
         }
 
-        public override async Task<ICollection<Domain.Model.Challenge>> PageAllAsync(int skip, int take)
+        public override async Task<ICollection<Domain.Model.Challenge>>
+            PageAllAsync(int skip, int take)
         {
             // todo: add logic to filter for user
             return await DbSet
@@ -41,7 +42,6 @@ namespace GRA.Data.Repository
 
         public override async Task<Domain.Model.Challenge> GetByIdAsync(int id)
         {
-            // todo: add logic to filter for user
             var challenge = mapper.Map<Model.Challenge, Domain.Model.Challenge>(await DbSet
                 .AsNoTracking()
                 .Where(_ => _.IsDeleted == false && _.Id == id)
@@ -64,7 +64,6 @@ namespace GRA.Data.Repository
 
         public override async Task RemoveSaveAsync(int userId, int id)
         {
-            // todo: fix user lookup
             var entity = await context.Challenges
                 .Where(_ => _.IsDeleted == false && _.Id == id)
                 .SingleAsync();
@@ -73,7 +72,8 @@ namespace GRA.Data.Repository
             await base.SaveAsync();
         }
 
-        public async Task<ICollection<Domain.Model.ChallengeTask>> GetChallengeTasksAsync(int challengeId)
+        public async Task<ICollection<Domain.Model.ChallengeTask>>
+            GetChallengeTasksAsync(int challengeId)
         {
             var tasks = await context.ChallengeTasks
                 .AsNoTracking()
@@ -85,8 +85,8 @@ namespace GRA.Data.Repository
             return await GetChallengeTasksTypeAsync(tasks);
         }
 
-        private async Task<ICollection<Domain.Model.ChallengeTask>> GetChallengeTasksTypeAsync(
-            ICollection<Domain.Model.ChallengeTask> tasks)
+        private async Task<ICollection<Domain.Model.ChallengeTask>>
+            GetChallengeTasksTypeAsync(ICollection<Domain.Model.ChallengeTask> tasks)
         {
             var challengeTaskTypes =
                 await context.ChallengeTaskTypes

--- a/src/GRA.Domain.Model/Permission.cs
+++ b/src/GRA.Domain.Model/Permission.cs
@@ -3,10 +3,12 @@
     public enum Permission
     {
         AccessMissionControl,
-        CanDeleteAllMail,
-        CanLogActivityForAll,
-        CanMailParticipants,
-        CanReadAllMail,
+        AddChallenges,
+        DeleteAllMail,
+        LogActivityForAll,
+        MailParticipants,
+        ReadAllMail,
+        RemoveChallenges,
         EditChallenges
     }
 }

--- a/src/GRA.Domain.Model/Policy.cs
+++ b/src/GRA.Domain.Model/Policy.cs
@@ -3,10 +3,12 @@
     public sealed class Policy
     {
         public const string AccessMissionControl = "AccessMissionControl";
-        public const string CanDeleteAllMail = "CanDeleteAllMail";
-        public const string CanLogActivityForAll = "CanLogActivityForAll";
-        public const string CanMailParticipants = "CanMailParticipants";
-        public const string CanReadAllMail = "CanReadAllMail";
+        public const string AddChallenges = "AddChallenges";
+        public const string DeleteAllMail = "DeleteAllMail";
+        public const string LogActivityForAll = "LogActivityForAll";
+        public const string MailParticipants = "MailParticipants";
+        public const string ReadAllMail = "ReadAllMail";
+        public const string RemoveChallenges = "RemoveChallenges";
         public const string EditChallenges = "EditChallenges";
     }
 }

--- a/src/GRA.Domain.Service/Abstract/BaseService.cs
+++ b/src/GRA.Domain.Service/Abstract/BaseService.cs
@@ -18,12 +18,12 @@ namespace GRA.Domain.Service.Abstract
             return new UserClaimLookup(user).UserHasPermission(permission.ToString());
         }
 
-        protected int GetId(ClaimsPrincipal user, string idClaim)
+        protected int GetId(ClaimsPrincipal user, string claimType)
         {
-            string result = new UserClaimLookup(user).UserClaim(idClaim);
+            string result = new UserClaimLookup(user).UserClaim(claimType);
             if(string.IsNullOrEmpty(result))
             {
-                throw new System.Exception($"Could not find user claim '{idClaim}'");
+                throw new System.Exception($"Could not find user claim '{claimType}'");
             }
             int id;
             if(int.TryParse(result, out id))
@@ -32,7 +32,7 @@ namespace GRA.Domain.Service.Abstract
             }
             else
             {
-                throw new System.Exception($"Could not convert '{idClaim}' to a number.");
+                throw new System.Exception($"Could not convert '{claimType}' to a number.");
             }
         }
     }

--- a/src/GRA.Domain.Service/ActivityService.cs
+++ b/src/GRA.Domain.Service/ActivityService.cs
@@ -40,7 +40,7 @@ namespace GRA.Domain.Service
             {
                 goodToLog = true;
             }
-            else if (claimLookup.UserHasPermission(Permission.CanLogActivityForAll.ToString()))
+            else if (claimLookup.UserHasPermission(Permission.LogActivityForAll.ToString()))
             {
                 goodToLog = true;
                 loggingAsAdminUser = true;

--- a/src/GRA.Domain.Service/MailService.cs
+++ b/src/GRA.Domain.Service/MailService.cs
@@ -42,7 +42,7 @@ namespace GRA.Domain.Service
         public async Task<Mail> GetDetails(ClaimsPrincipal user, int mailId)
         {
             var userId = GetId(user, ClaimType.UserId);
-            bool canReadAll = UserHasPermission(user, Permission.CanReadAllMail);
+            bool canReadAll = UserHasPermission(user, Permission.ReadAllMail);
             var mail = await _mailRepository.GetByIdAsync(mailId);
             if(mail.FromUserId == userId || mail.ToUserId == userId || canReadAll)
             {
@@ -57,7 +57,7 @@ namespace GRA.Domain.Service
             int skip,
             int take)
         {
-            if (UserHasPermission(user, Permission.CanReadAllMail))
+            if (UserHasPermission(user, Permission.ReadAllMail))
             {
                 var dataTask = _mailRepository.PageAllAsync(skip, take);
                 var countTask = _mailRepository.GetAllCountAsync();
@@ -81,7 +81,7 @@ namespace GRA.Domain.Service
             int skip,
             int take)
         {
-            if (UserHasPermission(user, Permission.CanReadAllMail))
+            if (UserHasPermission(user, Permission.ReadAllMail))
             {
                 var dataTask = _mailRepository.PageAdminUnreadAsync(skip, take);
                 var countTask = _mailRepository.GetAdminUnreadCountAsync();
@@ -116,7 +116,7 @@ namespace GRA.Domain.Service
         public async Task<Mail> SendAsync(ClaimsPrincipal user, Mail mail)
         {
             if(mail.ToUserId == default(int)
-               || UserHasPermission(user, Permission.CanMailParticipants))
+               || UserHasPermission(user, Permission.MailParticipants))
             {
                 mail.FromUserId = GetId(user, ClaimType.UserId);
                 mail.IsNew = true;
@@ -135,7 +135,7 @@ namespace GRA.Domain.Service
         public async Task RemoveAsync(ClaimsPrincipal user, int mailId)
         {
             var userId = GetId(user, ClaimType.UserId);
-            bool canDeleteAll = UserHasPermission(user, Permission.CanDeleteAllMail);
+            bool canDeleteAll = UserHasPermission(user, Permission.DeleteAllMail);
             var mail = await _mailRepository.GetByIdAsync(mailId);
             if (mail.FromUserId == userId || mail.ToUserId == userId || canDeleteAll)
             {


### PR DESCRIPTION
- Modify challenge service to perform authorization checks
- Add permissions/policies: `AddChallenges`, `RemoveChallenges`
- Refactor existing permissions/policies to remove `Can` as a prefix