### PR TITLE
Add user service/repository methods for admin

### DIFF
--- a/src/GRA.Domain.Model/Permission.cs
+++ b/src/GRA.Domain.Model/Permission.cs
@@ -4,11 +4,15 @@
     {
         AccessMissionControl,
         AddChallenges,
-        DeleteAllMail,
-        LogActivityForAll,
+        DeleteAnyMail,
+        DeleteParticipants,
+        EditChallenges,
+        EditParticipants,
+        LogActivityForAny,
         MailParticipants,
         ReadAllMail,
         RemoveChallenges,
-        EditChallenges
+        ViewParticipantList,
+        ViewParticipantDetails
     }
 }

--- a/src/GRA.Domain.Model/Policy.cs
+++ b/src/GRA.Domain.Model/Policy.cs
@@ -4,11 +4,15 @@
     {
         public const string AccessMissionControl = "AccessMissionControl";
         public const string AddChallenges = "AddChallenges";
-        public const string DeleteAllMail = "DeleteAllMail";
-        public const string LogActivityForAll = "LogActivityForAll";
+        public const string DeleteAnyMail = "DeleteAnyMail";
+        public const string DeleteParticipants = "DeleteParticipants";
+        public const string EditChallenges = "EditChallenges";
+        public const string EditParticipants = "EditParticipants";
+        public const string LogActivityForAny = "LogActivityForAny";
         public const string MailParticipants = "MailParticipants";
         public const string ReadAllMail = "ReadAllMail";
         public const string RemoveChallenges = "RemoveChallenges";
-        public const string EditChallenges = "EditChallenges";
+        public const string ViewParticipantList = "ViewParticipantList";
+        public const string ViewParticipantDetails = "ViewParticipantDetails";
     }
 }

--- a/src/GRA.Domain.Repository/IUserRepository.cs
+++ b/src/GRA.Domain.Repository/IUserRepository.cs
@@ -12,5 +12,6 @@ namespace GRA.Domain.Repository
         Task<Model.AuthenticationResult> AuthenticateUserAsync(string username, string password);
         Task<Model.User> GetByUsernameAsync(string username);
         Task SetUserPasswordAsync(int currentUserId, string password);
+        Task<int> GetCountAsync();
     }
 }

--- a/src/GRA.Domain.Service/ActivityService.cs
+++ b/src/GRA.Domain.Service/ActivityService.cs
@@ -40,7 +40,7 @@ namespace GRA.Domain.Service
             {
                 goodToLog = true;
             }
-            else if (claimLookup.UserHasPermission(Permission.LogActivityForAll.ToString()))
+            else if (claimLookup.UserHasPermission(Permission.LogActivityForAny.ToString()))
             {
                 goodToLog = true;
                 loggingAsAdminUser = true;

--- a/src/GRA.Domain.Service/MailService.cs
+++ b/src/GRA.Domain.Service/MailService.cs
@@ -135,7 +135,7 @@ namespace GRA.Domain.Service
         public async Task RemoveAsync(ClaimsPrincipal user, int mailId)
         {
             var userId = GetId(user, ClaimType.UserId);
-            bool canDeleteAll = UserHasPermission(user, Permission.DeleteAllMail);
+            bool canDeleteAll = UserHasPermission(user, Permission.DeleteAnyMail);
             var mail = await _mailRepository.GetByIdAsync(mailId);
             if (mail.FromUserId == userId || mail.ToUserId == userId || canDeleteAll)
             {

--- a/src/GRA.Domain.Service/UserService.cs
+++ b/src/GRA.Domain.Service/UserService.cs
@@ -3,34 +3,28 @@ using Microsoft.Extensions.Logging;
 using GRA.Domain.Model;
 using GRA.Domain.Repository;
 using System.Threading.Tasks;
+using System.Security.Claims;
+using System.Collections.Generic;
 
 namespace GRA.Domain.Service
 {
     public class UserService : Abstract.BaseService<UserService>
     {
-        private readonly IUserRepository userRepository;
-        private readonly IRoleRepository roleRepository;
+        private readonly IUserRepository _userRepository;
+        private readonly IRoleRepository _roleRepository;
         public UserService(ILogger<UserService> logger,
             IUserRepository userRepository,
             IRoleRepository roleRepository)
             : base(logger)
         {
-            if (userRepository == null)
-            {
-                throw new ArgumentNullException(nameof(userRepository));
-            }
-            this.userRepository = userRepository;
-            if (roleRepository == null)
-            {
-                throw new ArgumentNullException(nameof(roleRepository));
-            }
-            this.roleRepository = roleRepository;
+            _userRepository = Require.IsNotNull(userRepository, nameof(userRepository));
+            _roleRepository = Require.IsNotNull(roleRepository, nameof(roleRepository));
         }
 
         public async Task<AuthenticationResult> AuthenticateUserAsync(string username,
             string password)
         {
-            var authResult = await userRepository.AuthenticateUserAsync(username, password);
+            var authResult = await _userRepository.AuthenticateUserAsync(username, password);
 
             if (!authResult.FoundUser)
             {
@@ -42,8 +36,8 @@ namespace GRA.Domain.Service
             }
             else
             {
-                authResult.PermissionNames 
-                    = await roleRepository.GetPermisisonNamesForUserAsync(authResult.User.Id);
+                authResult.PermissionNames
+                    = await _roleRepository.GetPermisisonNamesForUserAsync(authResult.User.Id);
             }
             return authResult;
         }
@@ -54,9 +48,79 @@ namespace GRA.Domain.Service
             user.BranchId = 1;
             user.ProgramId = 1;
             user.SiteId = 1;
-            var registeredUser = await userRepository.AddSaveAsync(0, user);
-            await userRepository.SetUserPasswordAsync(registeredUser.Id, password);
+            var registeredUser = await _userRepository.AddSaveAsync(0, user);
+            await _userRepository.SetUserPasswordAsync(registeredUser.Id, password);
             return registeredUser;
+        }
+
+        public async Task<DataWithCount<IEnumerable<User>>>
+           GetPaginatedUserListAsync(ClaimsPrincipal user,
+           int skip,
+           int take)
+        {
+            if (UserHasPermission(user, Permission.ViewParticipantList))
+            {
+                var dataTask = _userRepository.PageAllAsync(skip, take);
+                var countTask = _userRepository.GetCountAsync();
+                await Task.WhenAll(dataTask, countTask);
+                return new DataWithCount<IEnumerable<User>>
+                {
+                    Data = dataTask.Result,
+                    Count = countTask.Result
+                };
+            } else
+            {
+                int userId = GetId(user, ClaimType.UserId);
+                logger.LogError($"User {userId} doesn't have permission to view all participants.");
+                throw new Exception("Permission denied.");
+            }
+        }
+
+        public async Task<User> GetDetails(ClaimsPrincipal user, int userId)
+        {
+            if (UserHasPermission(user, Permission.ViewParticipantDetails))
+            {
+                return await _userRepository.GetByIdAsync(userId);
+            }
+            else
+            {
+                int requestedByUserId = GetId(user, ClaimType.UserId);
+                logger.LogError($"User {requestedByUserId} doesn't have permission to view participant details.");
+                throw new Exception("Permission denied.");
+            }
+        }
+
+        public async Task<User> Update(ClaimsPrincipal user, User userToUpdate)
+        {
+            int requestedByUserId = GetId(user, ClaimType.UserId);
+
+            if (UserHasPermission(user, Permission.EditParticipants)
+                || requestedByUserId == userToUpdate.Id)
+            {
+                var currentEntity = await _userRepository.GetByIdAsync(userToUpdate.Id);
+                userToUpdate.SiteId = currentEntity.SiteId;
+                return await _userRepository.UpdateSaveAsync(requestedByUserId, userToUpdate);
+            }
+            else
+            {
+                logger.LogError($"User {requestedByUserId} doesn't have permission to update user {userToUpdate.Id}.");
+                throw new Exception("Permission denied.");
+            }
+        }
+
+        public async Task Remove(ClaimsPrincipal user, int userIdToRemove)
+        {
+            int requestedByUserId = GetId(user, ClaimType.UserId);
+
+            if (UserHasPermission(user, Permission.DeleteParticipants))
+            {
+                await _userRepository.RemoveSaveAsync(requestedByUserId, userIdToRemove);
+            }
+            else
+            {
+                logger.LogError($"User {requestedByUserId} doesn't have permission remove user {userIdToRemove}.");
+                throw new Exception("Permission denied.");
+            }
         }
     }
 }


### PR DESCRIPTION
- Add permissions/policies: `DeleteParticipants`, `EditParticipants`,
  `ViewParticipantList`, `ViewParticipantDetails`
- Rename permissions/policies: `DeleteAnyMail`, `LogActivityForAny`
  ("any" indicates a particular user and not all users in the system)
- User service calls: get all users (paginated), get specific user
  details, update user, delete user
- User repository methods to support service calls, make user deletion
  use `.IsDeleted` rather than delete the record.