### PR TITLE
Improve user history functionality

### DIFF
--- a/src/GRA.Data/Model/PointTranslation.cs
+++ b/src/GRA.Data/Model/PointTranslation.cs
@@ -18,5 +18,9 @@ namespace GRA.Data.Model
         public int PointsEarned { get; set; }
         [Required]
         public bool IsSingleEvent { get; set; }
+        [Required]
+        public string TranslationDescriptionPresentTense { get; set; }
+        [Required]
+        public string TranslationDescriptionPastTense { get; set; }
     }
 }

--- a/src/GRA.Data/Model/UserLog.cs
+++ b/src/GRA.Data/Model/UserLog.cs
@@ -17,6 +17,6 @@ namespace GRA.Data.Model
         [Required]
         public bool IsDeleted { get; set; }
         public int? DeletedBy { get; set; }
-        public int ChallengeId { get; set; }
+        public int? ChallengeId { get; set; }
     }
 }

--- a/src/GRA.Data/Repository/UserLogRepository.cs
+++ b/src/GRA.Data/Repository/UserLogRepository.cs
@@ -20,14 +20,64 @@ namespace GRA.Data.Repository
 
         public async Task<IEnumerable<UserLog>> PageHistoryAsync(int userId, int skip, int take)
         {
+            var userLogs = await DbSet
+               .AsNoTracking()
+               .Where(_ => _.UserId == userId)
+               .OrderBy(_ => _.CreatedAt)
+               .Skip(skip)
+               .Take(take)
+               .ProjectTo<UserLog>()
+               .ToListAsync();
+
+            foreach (var userLog in userLogs)
+            {
+                if (userLog.ChallengeId != null)
+                {
+                    var challenge = context.Challenges
+                        .AsNoTracking()
+                        .Where(_ => _.Id == userLog.ChallengeId)
+                        .SingleOrDefault();
+                    userLog.Description = $"Completed the {challenge.Name} challenge.";
+                }
+                else
+                {
+                    // used a point translation
+                    var translation = context.PointTranslations
+                        .AsNoTracking()
+                        .Where(_ => _.Id == userLog.PointTranslationId)
+                        .SingleOrDefault();
+                    if(translation.TranslationDescriptionPastTense.Contains("{0}"))
+                    {
+                        userLog.Description = string.Format(
+                            translation.TranslationDescriptionPastTense,
+                            userLog.ActivityEarned);
+                    }
+                    else
+                    {
+                        userLog.Description = translation.TranslationDescriptionPastTense;
+                    }
+                }
+            }
+
+            return userLogs;
+        }
+
+        public async Task<int> GetHistoryItemCountAsync(int userId)
+        {
             return await DbSet
                 .AsNoTracking()
                 .Where(_ => _.UserId == userId)
-                .OrderBy(_ => _.CreatedAt)
-                .Skip(skip)
-                .Take(take)
-                .ProjectTo<UserLog>()
-                .ToListAsync();
+                .CountAsync();
+        }
+
+        public async override Task RemoveSaveAsync(int userId, int id)
+        {
+            var entity = await DbSet
+                .Where(_ => _.IsDeleted == false && _.Id == id)
+                .SingleAsync();
+            entity.IsDeleted = true;
+            await base.UpdateAsync(userId, entity, null);
+            await base.SaveAsync();
         }
     }
 }

--- a/src/GRA.Domain.Model/PointTranslation.cs
+++ b/src/GRA.Domain.Model/PointTranslation.cs
@@ -18,5 +18,10 @@ namespace GRA.Domain.Model
         public int PointsEarned { get; set; }
         [Required]
         public bool IsSingleEvent { get; set; }
+        [Required]
+        public string TranslationDescriptionPresentTense { get; set; }
+        [Required]
+        public string TranslationDescriptionPastTense { get; set; }
+
     }
 }

--- a/src/GRA.Domain.Model/UserLog.cs
+++ b/src/GRA.Domain.Model/UserLog.cs
@@ -17,6 +17,7 @@ namespace GRA.Domain.Model
         [Required]
         public bool IsDeleted { get; set; }
         public int? DeletedBy { get; set; }
-        public int ChallengeId { get; set; }
+        public int? ChallengeId { get; set; }
+        public string Description { get; set; }
     }
 }

--- a/src/GRA.Domain.Repository/IUserLogRepository.cs
+++ b/src/GRA.Domain.Repository/IUserLogRepository.cs
@@ -6,5 +6,6 @@ namespace GRA.Domain.Repository
     public interface IUserLogRepository : IRepository<Model.UserLog>
     {
         Task<IEnumerable<Model.UserLog>> PageHistoryAsync(int userId, int skip, int take);
+        Task<int> GetHistoryItemCountAsync(int userId);
     }
 }

--- a/src/GRA.Domain.Repository/IUserRepository.cs
+++ b/src/GRA.Domain.Repository/IUserRepository.cs
@@ -1,23 +1,25 @@
-﻿using System.Collections.Generic;
+﻿using GRA.Domain.Model;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GRA.Domain.Repository
 {
-    public interface IUserRepository : IRepository<Model.User>
+    public interface IUserRepository : IRepository<User>
     {
-        Task<Model.User> AddPointsSaveAsync(int currentUserId,
+        Task<User> AddPointsSaveAsync(int currentUserId,
             int whoEarnedUserId,
             int pointsEarned,
             bool loggingAsAdminUser);
         Task AddRoleAsync(int currentUserId, int userId, int roleId);
-        Task<Model.AuthenticationResult> AuthenticateUserAsync(string username, string password);
-        Task<Model.User> GetByUsernameAsync(string username);
+        Task<AuthenticationResult> AuthenticateUserAsync(string username, string password);
+        Task<User> GetByUsernameAsync(string username);
         Task<int> GetCountAsync();
         Task<int> GetFamilyCountAsync(int householdHeadUserId);
         Task<IEnumerable<Model.User>> PageAllAsync(int siteId, int skip, int take);
 
         Task<IEnumerable<Model.User>>
             PageFamilyAsync(int householdHeadUserId, int skip, int take);
+        Task<User> RemovePointsSaveASync(int userId, int whoRemoveUserId, int pointsToRemove);
         Task SetUserPasswordAsync(int currentUserId, string password);
     }
 }

--- a/src/GRA.Domain.Service/ConfigurationService.cs
+++ b/src/GRA.Domain.Service/ConfigurationService.cs
@@ -131,7 +131,9 @@ namespace GRA.Domain.Service
                 IsSingleEvent = true,
                 PointsEarned = 10,
                 ProgramId = program.Id,
-                TranslationName = "One book, ten points"
+                TranslationName = "One book, ten points",
+                TranslationDescriptionPastTense = "Read {0} book",
+                TranslationDescriptionPresentTense = "Read {0} book"
             };
             await _pointTranslationRepository.AddSaveAsync(creatorUserId, pointTranslation);
 


### PR DESCRIPTION
- `UserLog` now has a `Description` property which displays the
  description of the logged activity in a form that can be shown to the
  participant or administrative user.
- Properly return paginated user history with a count :rage3:
- Added point translation descriptions to show users
- `UserLog` property `ChallengeId` is now nullable for line items which
  didn't come from a challenge.