### PR TITLE
Fix general admin issues

### DIFF
--- a/src/GRA.Controllers/Base/Controller.cs
+++ b/src/GRA.Controllers/Base/Controller.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using GRA.Domain.Model;
 using System.Security.Claims;
@@ -28,7 +26,7 @@ namespace GRA.Controllers.Base
             base.OnActionExecuted(context);
 
             // sensible default
-            string pageTitle = "Great Reading Adventure";
+            string pageTitle = _config[ConfigurationKeys.DefaultSiteName];
 
             // set page title
             var controller = context.Controller as Controller;

--- a/src/GRA.Controllers/Helpers/SiteHelper.cs
+++ b/src/GRA.Controllers/Helpers/SiteHelper.cs
@@ -1,9 +1,5 @@
-﻿using GRA.Domain.Model;
-using GRA.Domain.Service;
+﻿using GRA.Domain.Service;
 using Microsoft.AspNetCore.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace GRA.Controllers.Helpers

--- a/src/GRA.Controllers/Helpers/SiteTagHelper.cs
+++ b/src/GRA.Controllers/Helpers/SiteTagHelper.cs
@@ -1,14 +1,11 @@
 ﻿using GRA.Domain.Model;
 using GRA.Domain.Service;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace GRA.Controllers.Helpers
@@ -41,23 +38,34 @@ namespace GRA.Controllers.Helpers
             int siteId = await new SiteHelper(_siteService)
                 .GetSiteId(ViewContext.HttpContext, sitePath);
             Site site = await _siteService.GetById((int)siteId);
-            TagBuilder result;
-            switch(property)
+            string resultText = string.Empty;
+            TagBuilder resultTag = null;
+            switch(property.ToLower())
             {
                 case "name":
-                    result = new TagBuilder("span");
-                    result.InnerHtml.Append(site.Name);
+                    resultText = site.Name;
+                    break;
+                case "pagetitle":
+                    resultText = site.PageTitle;
                     break;
                 case "footer":
-                    result = new TagBuilder("p");
-                    result.AddCssClass("footer");
-                    result.InnerHtml.AppendHtml(site.Footer);
+                    resultTag = new TagBuilder("p");
+                    resultTag.AddCssClass("footer");
+                    resultTag.InnerHtml.AppendHtml(site.Footer);
                     break;
                 default:
                     throw new NotImplementedException();
             }
 
-            output.Content.SetHtmlContent(result);
+            if(resultTag != null)
+            {
+                output.Content.SetHtmlContent(resultTag);
+            }
+            else
+            {
+                output.Content.SetHtmlContent(resultText);
+            }
+            
         }
     }
 }

--- a/src/GRA.Controllers/HomeController.cs
+++ b/src/GRA.Controllers/HomeController.cs
@@ -1,8 +1,4 @@
-﻿using GRA.Controllers.Helpers;
-using GRA.Domain.Model;
-using GRA.Domain.Service;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 
@@ -16,7 +12,6 @@ namespace GRA.Controllers
             : base(context)
         {
             _logger = Require.IsNotNull(logger, nameof(logger));
-            PageTitle = "The Great Reading Adventure";
         }
 
         public async Task<IActionResult> Index(string sitePath = null)

--- a/src/GRA.Data.SQLite/SQLiteContext.cs
+++ b/src/GRA.Data.SQLite/SQLiteContext.cs
@@ -5,9 +5,8 @@ namespace GRA.Data.SQLite
 {
     public class SQLiteContext : Context
     {
-        private const string defaultDevCs = "Filename=./gra4.db";
         public SQLiteContext(IConfigurationRoot config) : base(config) {}
-        internal SQLiteContext() : base(defaultDevCs) { }
+        internal SQLiteContext() : base(DefaultConnectionString.SQLite) { }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -17,7 +16,7 @@ namespace GRA.Data.SQLite
             }
             else
             {
-                optionsBuilder.UseSqlite(config["ConnectionStrings:DefaultConnection"]);
+                optionsBuilder.UseSqlite(config[ConfigurationKeys.DefaultCSSQLite]);
             }
         }
     }

--- a/src/GRA.Data.SQLite/project.json
+++ b/src/GRA.Data.SQLite/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-*",
 
   "dependencies": {
+    "GRA": "1.0.0-*",
     "GRA.Data": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.Design": "1.1.0",
     "Microsoft.EntityFrameworkCore.Sqlite": "1.1.0",

--- a/src/GRA.Data.SqlServer/SqlServerContext.cs
+++ b/src/GRA.Data.SqlServer/SqlServerContext.cs
@@ -5,9 +5,8 @@ namespace GRA.Data.SqlServer
 {
     public class SqlServerContext : Context
     {
-        private const string defaultDevCs = @"Server=(localdb)\mssqllocaldb;Database=gra4;Trusted_Connection=True;MultipleActiveResultSets=true";
         public SqlServerContext(IConfigurationRoot config) : base(config) { }
-        internal SqlServerContext() : base(defaultDevCs) { }
+        internal SqlServerContext() : base(DefaultConnectionString.SqlServer) { }
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!string.IsNullOrEmpty(devConnectionString))
@@ -16,7 +15,7 @@ namespace GRA.Data.SqlServer
             }
             else
             {
-                optionsBuilder.UseSqlServer(config["ConnectionStrings:DefaultConnection"]);
+                optionsBuilder.UseSqlServer(config[ConfigurationKeys.DefaultCSSqlServer]);
             }
         }
     }

--- a/src/GRA.Data.SqlServer/project.json
+++ b/src/GRA.Data.SqlServer/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-*",
 
   "dependencies": {
+    "GRA": "1.0.0-*",
     "GRA.Data": "1.0.0-*",
     "Microsoft.EntityFrameworkCore.Design": "1.1.0",
     "Microsoft.EntityFrameworkCore.SqlServer": "1.1.0",

--- a/src/GRA.Data/Model/Site.cs
+++ b/src/GRA.Data/Model/Site.cs
@@ -12,6 +12,9 @@ namespace GRA.Data.Model
         [Required]
         [MaxLength(255)]
         public string Name { get; set; }
+        [Required]
+        [MaxLength(255)]
+        public string PageTitle { get; set; }
         [MaxLength(255)]
         public string Domain { get; set; }
         public bool IsDefault { get; set; }

--- a/src/GRA.Data/Model/User.cs
+++ b/src/GRA.Data/Model/User.cs
@@ -12,8 +12,13 @@ namespace GRA.Data.Model
         [MaxLength(254)]
         public string Email { get; set; }
         public bool IsDeleted { get; set; }
+        public bool CanBeDeleted { get; set; }
         public bool IsLockedOut { get; set; }
+        public DateTime LockedOutAt { get; set; }
+        public string LockedOutFor { get; set; }
+
         public bool IsAchiever { get; set; }
+
         [MaxLength(36)]
         public string Username { get; set; }
         public string PasswordHash { get; set; }

--- a/src/GRA.Data/Repository/UserLogRepository.cs
+++ b/src/GRA.Data/Repository/UserLogRepository.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using GRA.Domain.Repository;
 using GRA.Domain.Model;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +37,7 @@ namespace GRA.Data.Repository
                         .AsNoTracking()
                         .Where(_ => _.Id == userLog.ChallengeId)
                         .SingleOrDefault();
-                    userLog.Description = $"Completed the {challenge.Name} challenge.";
+                    userLog.Description = $"Completed challenge: {challenge.Name}";
                 }
                 else
                 {

--- a/src/GRA.Domain.Model/Site.cs
+++ b/src/GRA.Domain.Model/Site.cs
@@ -11,6 +11,9 @@ namespace GRA.Domain.Model
         [Required]
         [MaxLength(255)]
         public string Name { get; set; }
+        [Required]
+        [MaxLength(255)]
+        public string PageTitle { get; set; }
         [MaxLength(255)]
         public string Domain { get; set; }
         public bool IsDefault { get; set; }

--- a/src/GRA.Domain.Model/SortUsersBy.cs
+++ b/src/GRA.Domain.Model/SortUsersBy.cs
@@ -1,0 +1,10 @@
+﻿namespace GRA.Domain.Model
+{
+    public enum SortUsersBy
+    {
+        FirstName,
+        LastName,
+        Username,
+        RegistrationDate
+    }
+}

--- a/src/GRA.Domain.Model/User.cs
+++ b/src/GRA.Domain.Model/User.cs
@@ -11,7 +11,10 @@ namespace GRA.Domain.Model
         [MaxLength(254)]
         public string Email { get; set; }
         public bool IsDeleted { get; set; }
+        public bool CanBeDeleted { get; set; }
         public bool IsLockedOut { get; set; }
+        public DateTime LockedOutAt { get; set; }
+        public string LockedOutFor { get; set; }
         public bool IsAchiever { get; set; }
         [MaxLength(36)]
         public string Username { get; set; }

--- a/src/GRA.Domain.Repository/IUserRepository.cs
+++ b/src/GRA.Domain.Repository/IUserRepository.cs
@@ -15,8 +15,10 @@ namespace GRA.Domain.Repository
         Task<User> GetByUsernameAsync(string username);
         Task<int> GetCountAsync();
         Task<int> GetFamilyCountAsync(int householdHeadUserId);
-        Task<IEnumerable<Model.User>> PageAllAsync(int siteId, int skip, int take);
-
+        Task<IEnumerable<Model.User>> PageAllAsync(int siteId, 
+            int skip, 
+            int take, 
+            SortUsersBy sortBy = SortUsersBy.LastName);
         Task<IEnumerable<Model.User>>
             PageFamilyAsync(int householdHeadUserId, int skip, int take);
         Task<User> RemovePointsSaveASync(int userId, int whoRemoveUserId, int pointsToRemove);

--- a/src/GRA.Domain.Service/ConfigurationService.cs
+++ b/src/GRA.Domain.Service/ConfigurationService.cs
@@ -91,6 +91,7 @@ namespace GRA.Domain.Service
             adminUser.ProgramId = program.Id;
             adminUser.SiteId = site.Id;
             adminUser.SystemId = system.Id;
+            adminUser.CanBeDeleted = false;
             var user = await _userRepository.AddSaveAsync(0, adminUser);
             await _userRepository.SetUserPasswordAsync(user.Id, user.Id, password);
 
@@ -216,7 +217,7 @@ namespace GRA.Domain.Service
             {
                 Body = "Your administrative account has been created successfully!",
                 FromUserId = creatorUserId,
-                Subject = "Welcome to The Great Reading Adventure!"
+                Subject = $"Welcome to {site.Name}"
             });
 
             // add some family users
@@ -238,7 +239,7 @@ namespace GRA.Domain.Service
             {
                 Body = "Your account has been created successfully!",
                 FromUserId = arthur.Id,
-                Subject = "Welcome to The Great Reading Adventure!"
+                Subject = $"Welcome to {site.Name}!"
             });
 
             newUser.FirstName = "Molly";

--- a/src/GRA.Domain.Service/project.json
+++ b/src/GRA.Domain.Service/project.json
@@ -7,6 +7,7 @@
     "GRA.Domain.Repository": "1.0.0-*",
     "Microsoft.EntityFrameworkCore": "1.1.0",
     "Microsoft.Extensions.Caching.Memory": "1.1.0",
+    "Microsoft.Extensions.Configuration.Abstractions": "1.1.0",
     "Microsoft.Extensions.Logging.Abstractions": "1.1.0",
     "NETStandard.Library": "1.6.1",
     "System.Security.Claims": "4.3.0"

--- a/src/GRA.Web/Areas/MissionControl/Views/Shared/_Layout.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Shared/_Layout.cshtml
@@ -39,7 +39,7 @@
                    asp-action="Index"
                    class="navbar-brand mc-navbar-brand">
                     <span class="fa fa-space-shuttle"></span>
-                    Mission Control: <grasite property="name"></grasite>
+                    Mission Control: <grasite property="pageTitle"></grasite>
                 </a>
             </div>
             <div class="navbar-collapse navbar-right collapse">

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using GRA.Controllers.RouteConstraint;
-using GRA.Domain.Model;
+using GRA.Controllers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -22,10 +22,14 @@ namespace GRA.Web
                 .AddEnvironmentVariables();
 
             Configuration = builder.Build();
+            Configuration[ConfigurationKeys.DefaultSiteName] = "The Great Reading Adventure";
+            Configuration[ConfigurationKeys.DefaultPageTitle] = "Great Reading Adventure";
+            Configuration[ConfigurationKeys.DefaultSitePath] = "gra";
+            Configuration[ConfigurationKeys.DefaultFooter] = "This site is running the open source <a href=\"http://www.greatreadingadventure.com/\">Great Reading Adventure</a> software developed by the <a href=\"https://mcldaz.org/\">Maricopa County Library District</a> with support by the <a href=\"http://www.azlibrary.gov/\">Arizona State Library, Archives and Public Records</a>, a division of the Secretary of State, and with federal funds from the <a href=\"http://www.imls.gov/\">Institute of Museum and Library Services</a>.";
             if (env.IsDevelopment())
             {
-                Configuration["ConnectionStrings:DefaultConnection"] = @"Server=(localdb)\mssqllocaldb;Database=gra4;Trusted_Connection=True;MultipleActiveResultSets=true";
-                //Configuration["ConnectionStrings:DefaultConnection"] = @"Filename=./gra4.db";
+                Configuration[ConfigurationKeys.DefaultCSSqlServer] = DefaultConnectionString.SqlServer;
+                Configuration[ConfigurationKeys.DefaultCSSQLite] = DefaultConnectionString.SQLite;
             }
         }
 

--- a/src/GRA.Web/Views/Home/Index.cshtml
+++ b/src/GRA.Web/Views/Home/Index.cshtml
@@ -17,8 +17,8 @@
     </div>
     <div class="col-sm-6">
         <p>
-            Welcome to the Great Reading Adventure Demo site. Feel free to sign up and get a feel
-            for how The Great Reading Adventure software works.
+            Welcome to <grasite property="name"></grasite> site. Feel free to sign up and get a feel
+            for how <grasite property="name"></grasite> works.
             <div class="row" style="margin-top: 2em;">
                 <div class="col-sm-6" style="margin-top: 0.5em;">
                     <a href="join" class="btn btn-primary btn-block btn-lg">

--- a/src/GRA.Web/Views/Shared/_Layout.cshtml
+++ b/src/GRA.Web/Views/Shared/_Layout.cshtml
@@ -39,7 +39,7 @@
                     <span class="icon-bar"></span>
                 </button>
                 <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">
-                    <grasite property="name"></grasite>
+                    <grasite property="pageTitle"></grasite>
                 </a>
             </div>
             <div class="navbar-collapse navbar-right collapse">

--- a/src/GRA/ConfigurationKeys.cs
+++ b/src/GRA/ConfigurationKeys.cs
@@ -1,0 +1,12 @@
+﻿namespace GRA
+{
+    public static class ConfigurationKeys
+    {
+        public const string DefaultCSSQLite = "ConnectionStrings:SQLite";
+        public const string DefaultCSSqlServer = "ConnectionStrings:SqlServer";
+        public const string DefaultFooter = "GraDefaultFooter";
+        public const string DefaultPageTitle = "GraDefaultPageTitle";
+        public const string DefaultSiteName = "GraDefaultSiteName";
+        public const string DefaultSitePath = "GraDefaultSitePath";
+    }
+}

--- a/src/GRA/DefaultConnectionString.cs
+++ b/src/GRA/DefaultConnectionString.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GRA
+{
+    public static class DefaultConnectionString
+    {
+        public const string SqlServer = @"Server=(localdb)\mssqllocaldb;Database=gra4;Trusted_Connection=True;MultipleActiveResultSets=true";
+        public const string SQLite = @"Filename=./gra4.db";
+    }
+}


### PR DESCRIPTION
- Add ability to sort patron list
- Limit what changes users can make to their own profile
- Add `CanDelete` option to `User` to protect primary admin user from
  deletion
- Move all product information into config file
- Move developer connection strings to constants
- Add site `PageTitle` to be distinct from `Name`
- Disallow deletion of household head user if they still have household
  members