### PR TITLE
Add timeout redirect and site filters, streamline auth code entry

### DIFF
--- a/src/GRA.Controllers/Base/Controller.cs
+++ b/src/GRA.Controllers/Base/Controller.cs
@@ -8,10 +8,11 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using GRA.Domain.Service;
 using GRA.Domain.Service.Abstract;
-using GRA.Web.Filter;
+using GRA.Controllers.Filter;
 
 namespace GRA.Controllers.Base
 {
+    [ServiceFilter(typeof(SiteFilter))]
     [SessionTimeoutFilter]
     public abstract class Controller : Microsoft.AspNetCore.Mvc.Controller
     {
@@ -128,15 +129,15 @@ namespace GRA.Controllers.Base
             return new UserClaimLookup(AuthUser).GetId(claimType);
         }
 
-        protected async Task<int> GetCurrentSiteId(string sitePath)
+        protected int GetCurrentSiteId(string sitePath)
         {
-            var context = await _userContextProvider.GetContext();
+            var context = _userContextProvider.GetContext();
             return context.SiteId;
         }
 
         protected async Task<Site> GetCurrentSite(string sitePath)
         {
-            return await _siteLookupService.GetById(await GetCurrentSiteId(sitePath));
+            return await _siteLookupService.GetById(GetCurrentSiteId(sitePath));
         }
 
         protected int GetActiveUserId()

--- a/src/GRA.Controllers/Base/Controller.cs
+++ b/src/GRA.Controllers/Base/Controller.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using GRA.Domain.Service;
 using GRA.Domain.Service.Abstract;
+using GRA.Web.Filter;
 
 namespace GRA.Controllers.Base
 {
+    [SessionTimeoutFilter]
     public abstract class Controller : Microsoft.AspNetCore.Mvc.Controller
     {
         protected readonly IConfigurationRoot _config;
@@ -99,7 +101,7 @@ namespace GRA.Controllers.Base
             }
         }
 
-        protected async Task LogoutUserAsync()
+        public async Task LogoutUserAsync()
         {
             HttpContext.Session.Clear();
             await HttpContext.Authentication.SignOutAsync(Authentication.SchemeGRACookie);

--- a/src/GRA.Controllers/ChallengesController.cs
+++ b/src/GRA.Controllers/ChallengesController.cs
@@ -23,8 +23,7 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Index(string Search, int page = 1, string sitePath = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
-            int siteId = await GetCurrentSiteId(sitePath);
+            int siteId = GetCurrentSiteId(sitePath);
             int take = 15;
             int skip = take * (page - 1);
 
@@ -70,8 +69,6 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Detail(int id, string sitePath = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
-
             var challenge = await _challengeService.GetChallengeDetailsAsync(id);
 
             ChallengeDetailViewModel viewModel = new ChallengeDetailViewModel()

--- a/src/GRA.Controllers/Filter/SessionTimeoutFilter.cs
+++ b/src/GRA.Controllers/Filter/SessionTimeoutFilter.cs
@@ -1,10 +1,9 @@
-﻿using GRA.Controllers;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
 using System.Threading.Tasks;
 
-namespace GRA.Web.Filter
+namespace GRA.Controllers.Filter
 {
     public class SessionTimeoutFilter : Attribute, IActionFilter
     {

--- a/src/GRA.Controllers/Filter/SessionTimeoutFilter.cs
+++ b/src/GRA.Controllers/Filter/SessionTimeoutFilter.cs
@@ -1,0 +1,35 @@
+﻿using GRA.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+using System.Threading.Tasks;
+
+namespace GRA.Web.Filter
+{
+    public class SessionTimeoutFilter : Attribute, IActionFilter
+    {
+        public void OnActionExecuted(ActionExecutedContext context)
+        {
+            if (context.HttpContext.Session.GetInt32(SessionKey.ActiveUserId) == null
+                && context.HttpContext.User.Identity.IsAuthenticated)
+            {
+                // no session but logged in - log out, redirect
+                var controller = (Controllers.Base.Controller)context.Controller;
+                Task.WaitAll(controller.LogoutUserAsync());
+                // TODO move this message to a customizable location
+                controller.TempData[TempDataKey.AlertWarning] = "Your session has expired. Please sign in again.";
+
+                context.Result = controller.RedirectToRoute(new
+                {
+                    area = string.Empty,
+                    controller = "SignIn",
+                    action = "Index"
+                });
+            }
+        }
+
+        public void OnActionExecuting(ActionExecutingContext context)
+        {
+        }
+    }
+}

--- a/src/GRA.Controllers/Filter/SiteFilter.cs
+++ b/src/GRA.Controllers/Filter/SiteFilter.cs
@@ -1,0 +1,59 @@
+﻿using GRA.Domain.Service;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GRA.Controllers.Filter
+{
+    public class SiteFilter : Attribute, IAsyncResourceFilter
+    {
+        private readonly SiteLookupService _siteLookupService;
+        public SiteFilter(SiteLookupService siteLookupService)
+        {
+            _siteLookupService = Require.IsNotNull(siteLookupService, nameof(siteLookupService));
+        }
+
+        public async Task OnResourceExecutionAsync(ResourceExecutingContext context,
+            ResourceExecutionDelegate next)
+        {
+            var httpContext = context.HttpContext;
+            // if we've already fetched it on this request it's present in Items
+            int? siteId = null;
+            if (httpContext.User.Identity.IsAuthenticated)
+            {
+                // if the user is authenticated, that is their site
+                siteId = new UserClaimLookup(httpContext.User).GetId(ClaimType.SiteId);
+            }
+            else
+            {
+                string sitePath = context.RouteData.Values["sitePath"]?.ToString();
+                // first check, did they use a sitePath giving them a specific site
+                if (!string.IsNullOrEmpty(sitePath))
+                {
+                    var site = await _siteLookupService.GetSiteByPath(sitePath);
+                    if (site != null)
+                    {
+                        siteId = site.Id;
+                    }
+                }
+                // if not check if they already have one in their session
+                if (siteId == null)
+                {
+                    siteId = httpContext.Session.GetInt32(SessionKey.SiteId);
+                }
+                // if not then resort to the default
+                if (siteId == null)
+                {
+                    siteId = await _siteLookupService.GetDefaultSiteId();
+                }
+            }
+            httpContext.Session.SetInt32(SessionKey.SiteId, (int)siteId);
+            httpContext.Items[SessionKey.SiteId] = (int)siteId;
+
+            await next();
+        }
+    }
+}

--- a/src/GRA.Controllers/Helpers/SiteTagHelper.cs
+++ b/src/GRA.Controllers/Helpers/SiteTagHelper.cs
@@ -39,8 +39,7 @@ namespace GRA.Controllers.Helpers
         {
             IUrlHelper url = _urlHelperFactory.GetUrlHelper(ViewContext);
             var routeData = url.ActionContext.RouteData.Values;
-            string sitePath = routeData["sitePath"] as string;
-            var userContext = await _userContextProvider.GetContext();
+            var userContext = _userContextProvider.GetContext();
             int siteId = userContext.SiteId;
             Site site = await _siteLookupService.GetById((int)siteId);
             switch (property.ToLower())

--- a/src/GRA.Controllers/HomeController.cs
+++ b/src/GRA.Controllers/HomeController.cs
@@ -26,7 +26,6 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Index(string sitePath = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
             var site = await GetCurrentSite(sitePath);
             if (site != null)
             {

--- a/src/GRA.Controllers/JoinController.cs
+++ b/src/GRA.Controllers/JoinController.cs
@@ -34,8 +34,6 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Index(string sitePath = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
-
             var site = await GetCurrentSite(sitePath);
             PageTitle = $"{site.Name} - Join Now!";
 
@@ -52,8 +50,6 @@ namespace GRA.Controllers
         [HttpPost]
         public async Task<IActionResult> Index(JoinViewModel model, string sitePath = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
-
             var site = await GetCurrentSite(sitePath);
 
             if (ModelState.IsValid)

--- a/src/GRA.Controllers/SignInController.cs
+++ b/src/GRA.Controllers/SignInController.cs
@@ -26,8 +26,6 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Index(string sitePath = null, string ReturnUrl = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
-
             var site = await GetCurrentSite(sitePath);
             PageTitle = $"Sign In to {site.Name}";
 
@@ -39,8 +37,6 @@ namespace GRA.Controllers
         [HttpPost]
         public async Task<IActionResult> Index(SignInViewModel model, string sitePath = null)
         {
-            HttpContext.Items["sitePath"] = sitePath;
-
             if (ModelState.IsValid)
             {
                 var loginAttempt = await _authenticationService

--- a/src/GRA.Domain.Service/Abstract/BaseUserService.cs
+++ b/src/GRA.Domain.Service/Abstract/BaseUserService.cs
@@ -18,11 +18,11 @@ namespace GRA.Domain.Service.Abstract
         private UserContext userContext = null;
         private ClaimsPrincipal currentUser = null;
         private int? currentUserSiteId = null;
-        protected async Task<ClaimsPrincipal> GetAuthUser()
+        protected ClaimsPrincipal GetAuthUser()
         {
             if (userContext == null)
             {
-                userContext = await _userContextProvider.GetContext();
+                userContext = _userContextProvider.GetContext();
             }
             if (currentUser == null)
             {
@@ -31,11 +31,11 @@ namespace GRA.Domain.Service.Abstract
             return currentUser;
         }
 
-        protected async Task<int> GetCurrentSiteId()
+        protected int GetCurrentSiteId()
         {
             if (userContext == null)
             {
-                userContext = await _userContextProvider.GetContext();
+                userContext = _userContextProvider.GetContext();
             }
             if (currentUserSiteId == null)
             {
@@ -44,23 +44,23 @@ namespace GRA.Domain.Service.Abstract
             return (int)currentUserSiteId;
         }
 
-        protected async Task<bool> HasPermission(Permission permission)
+        protected bool HasPermission(Permission permission)
         {
-            var currentUser = await GetAuthUser();
+            var currentUser = GetAuthUser();
             return new UserClaimLookup(currentUser).UserHasPermission(permission.ToString());
         }
 
-        protected async Task<int> GetClaimId(string claimType)
+        protected int GetClaimId(string claimType)
         {
-            var currentUser = await GetAuthUser();
+            var currentUser = GetAuthUser();
             return new UserClaimLookup(currentUser).GetId(claimType);
         }
 
-        protected async Task<int> GetActiveUserId()
+        protected int GetActiveUserId()
         {
             if (userContext == null)
             {
-                userContext = await _userContextProvider.GetContext();
+                userContext = _userContextProvider.GetContext();
             }
             if(userContext == null
                || !userContext.User.Identity.IsAuthenticated

--- a/src/GRA.Domain.Service/Abstract/IUserContextProvider.cs
+++ b/src/GRA.Domain.Service/Abstract/IUserContextProvider.cs
@@ -4,6 +4,6 @@ namespace GRA.Domain.Service.Abstract
 {
     public interface IUserContextProvider
     {
-        Task<UserContext> GetContext();
+        UserContext GetContext();
     }
 }

--- a/src/GRA.Domain.Service/ActivityService.cs
+++ b/src/GRA.Domain.Service/ActivityService.cs
@@ -36,15 +36,15 @@ namespace GRA.Domain.Service
             bool goodToLog = false;
             bool loggingAsAdminUser = false;
 
-            int activeUserId = await GetActiveUserId();
-            int authUserId = await GetClaimId(ClaimType.UserId);
+            int activeUserId = GetActiveUserId();
+            int authUserId = GetClaimId(ClaimType.UserId);
             var userToLog = await _userRepository.GetByIdAsync(userIdToLog);
 
             if (activeUserId == userIdToLog)
             {
                 goodToLog = true;
             }
-            else if (await HasPermission(Permission.LogActivityForAny))
+            else if (HasPermission(Permission.LogActivityForAny))
             {
                 goodToLog = true;
                 loggingAsAdminUser = true;
@@ -94,8 +94,8 @@ namespace GRA.Domain.Service
         public async Task<User> RemoveActivityAsync(int userIdToLog,
             int userLogIdToRemove)
         {
-            int currentUserId = await GetClaimId(ClaimType.UserId);
-            if(await HasPermission(Permission.LogActivityForAny))
+            int currentUserId = GetClaimId(ClaimType.UserId);
+            if(HasPermission(Permission.LogActivityForAny))
             {
                 var userLog = await _userLogRepository.GetByIdAsync(userLogIdToRemove);
 
@@ -114,14 +114,14 @@ namespace GRA.Domain.Service
 
         public async Task AddBook(int userId, Book book)
         {
-            int activeUserId = await GetActiveUserId();
+            int activeUserId = GetActiveUserId();
             var activeUser = await _userRepository.GetByIdAsync(activeUserId);
-            int authUserId = await GetClaimId(ClaimType.UserId);
+            int authUserId = GetClaimId(ClaimType.UserId);
 
 
             if (userId == activeUserId
                 || activeUser.HouseholdHeadUserId == authUserId
-                || await HasPermission(Permission.LogActivityForAny))
+                || HasPermission(Permission.LogActivityForAny))
             {
                 await _bookRepository.AddSaveForUserAsync(activeUserId, userId, book);
             }
@@ -134,9 +134,9 @@ namespace GRA.Domain.Service
 
         public async Task RemoveBook(int userId, int bookId)
         {
-            int requestedByUserId = await GetClaimId(ClaimType.UserId);
+            int requestedByUserId = GetClaimId(ClaimType.UserId);
             if (requestedByUserId == userId
-                || await HasPermission(Permission.LogActivityForAny))
+                || HasPermission(Permission.LogActivityForAny))
             {
                 await _bookRepository.RemoveForUserAsync(requestedByUserId, userId, bookId);
             }
@@ -150,9 +150,9 @@ namespace GRA.Domain.Service
 
         public async Task UpdateBook(int userId, Book book)
         {
-            int requestedByUserId = await GetClaimId(ClaimType.UserId);
+            int requestedByUserId = GetClaimId(ClaimType.UserId);
             if (requestedByUserId == userId
-                || await HasPermission(Permission.LogActivityForAny))
+                || HasPermission(Permission.LogActivityForAny))
             {
                 await _bookRepository.UpdateSaveAsync(requestedByUserId, book);
             }

--- a/src/GRA.Domain.Service/AuthenticationService.cs
+++ b/src/GRA.Domain.Service/AuthenticationService.cs
@@ -46,6 +46,18 @@ namespace GRA.Domain.Service
             }
             return authResult;
         }
+
+        public async Task<AuthenticationResult> RevalidateUserAsync(int userId)
+        {
+            return new AuthenticationResult
+            {
+                FoundUser = true,
+                PasswordIsValid = true,
+                PermissionNames = await _roleRepository.GetPermisisonNamesForUserAsync(userId),
+                User = await _userRepository.GetByIdAsync(userId)
+            };
+        }
+
         public async Task ResetPassword(int userIdToReset, string password)
         {
             int userId = await GetClaimId(ClaimType.UserId);

--- a/src/GRA.Domain.Service/AuthenticationService.cs
+++ b/src/GRA.Domain.Service/AuthenticationService.cs
@@ -60,9 +60,9 @@ namespace GRA.Domain.Service
 
         public async Task ResetPassword(int userIdToReset, string password)
         {
-            int userId = await GetClaimId(ClaimType.UserId);
+            int userId = GetClaimId(ClaimType.UserId);
             if (userId == userIdToReset
-                || await HasPermission(Permission.EditParticipants))
+                || HasPermission(Permission.EditParticipants))
             {
                 await _userRepository.SetUserPasswordAsync(userId, userIdToReset, password);
             }

--- a/src/GRA.Domain.Service/ChallengeService.cs
+++ b/src/GRA.Domain.Service/ChallengeService.cs
@@ -26,14 +26,11 @@ namespace GRA.Domain.Service
             GetPaginatedChallengeListAsync(int skip,
             int take)
         {
-            int siteId = await GetCurrentSiteId();
-            var dataTask = _challengeRepository.PageAllAsync(siteId, skip, take);
-            var countTask = _challengeRepository.GetChallengeCountAsync();
-            await Task.WhenAll(dataTask, countTask);
+            int siteId = GetCurrentSiteId();
             return new DataWithCount<IEnumerable<Challenge>>
             {
-                Data = dataTask.Result,
-                Count = countTask.Result
+                Data = await _challengeRepository.PageAllAsync(siteId, skip, take),
+                Count = await _challengeRepository.GetChallengeCountAsync()
             };
         }
 
@@ -44,69 +41,69 @@ namespace GRA.Domain.Service
 
         public async Task<Challenge> AddChallengeAsync(Challenge challenge)
         {
-            if (await HasPermission(Permission.AddChallenges))
+            if (HasPermission(Permission.AddChallenges))
             {
                 challenge.IsDeleted = false;
-                challenge.SiteId = await GetCurrentSiteId();
-                challenge.RelatedBranchId = await GetClaimId(ClaimType.BranchId);
-                challenge.RelatedSystemId = await GetClaimId(ClaimType.SystemId);
+                challenge.SiteId = GetCurrentSiteId();
+                challenge.RelatedBranchId = GetClaimId(ClaimType.BranchId);
+                challenge.RelatedSystemId = GetClaimId(ClaimType.SystemId);
                 return await _challengeRepository
-                    .AddSaveAsync(await GetClaimId(ClaimType.UserId), challenge);
+                    .AddSaveAsync(GetClaimId(ClaimType.UserId), challenge);
             }
-            int userId = await GetClaimId(ClaimType.UserId);
+            int userId = GetClaimId(ClaimType.UserId);
             _logger.LogError($"User {userId} doesn't have permission to add a challenge.");
             throw new Exception("Permission denied.");
         }
 
         public async Task<Challenge> EditChallengeAsync(Challenge challenge)
         {
-            if (await HasPermission(Permission.EditChallenges))
+            if (HasPermission(Permission.EditChallenges))
             {
                 var currentChallenge = await _challengeRepository.GetByIdAsync(challenge.Id);
                 challenge.SiteId = currentChallenge.SiteId;
                 challenge.RelatedBranchId = currentChallenge.RelatedBranchId;
                 challenge.RelatedSystemId = currentChallenge.RelatedSystemId;
                 return await _challengeRepository
-                    .UpdateSaveAsync(await GetClaimId(ClaimType.UserId), challenge);
+                    .UpdateSaveAsync(GetClaimId(ClaimType.UserId), challenge);
             }
-            int userId = await GetClaimId(ClaimType.UserId);
+            int userId = GetClaimId(ClaimType.UserId);
             _logger.LogError($"User {userId} doesn't have permission to edit challenge {challenge.Id}.");
             throw new Exception("Permission denied.");
         }
 
         public async Task RemoveChallengeAsync(int challengeId)
         {
-            if (await HasPermission(Permission.RemoveChallenges))
+            if (HasPermission(Permission.RemoveChallenges))
             {
                 await _challengeRepository
-                    .RemoveSaveAsync(await GetClaimId(ClaimType.UserId), challengeId);
+                    .RemoveSaveAsync(GetClaimId(ClaimType.UserId), challengeId);
             }
             else
             {
-                int userId = await GetClaimId(ClaimType.UserId);
+                int userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to remove challenge {challengeId}.");
                 throw new Exception("Permission denied.");
             }
         }
         public async Task<ChallengeTask> AddTaskAsync(ChallengeTask task)
         {
-            if (await HasPermission(Permission.EditChallenges))
+            if (HasPermission(Permission.EditChallenges))
             {
-                return await _challengeTaskRepository.AddSaveAsync(await GetClaimId(ClaimType.UserId), task);
+                return await _challengeTaskRepository.AddSaveAsync(GetClaimId(ClaimType.UserId), task);
             }
-            int userId = await GetClaimId(ClaimType.UserId);
+            int userId = GetClaimId(ClaimType.UserId);
             _logger.LogError($"User {userId} doesn't have permission to add a task to challenge {task.ChallengeId}.");
             throw new Exception("Permission denied.");
         }
 
         public async Task<ChallengeTask> EditTaskAsync(ChallengeTask task)
         {
-            if (await HasPermission(Permission.EditChallenges))
+            if (HasPermission(Permission.EditChallenges))
             {
                 return await _challengeTaskRepository
-                    .UpdateSaveAsync(await GetClaimId(ClaimType.UserId), task);
+                    .UpdateSaveAsync(GetClaimId(ClaimType.UserId), task);
             }
-            int userId = await GetClaimId(ClaimType.UserId);
+            int userId = GetClaimId(ClaimType.UserId);
             _logger.LogError($"User {userId} doesn't have permission to edit a task for challenge {task.ChallengeId}.");
             throw new Exception("Permission denied.");
         }
@@ -118,14 +115,14 @@ namespace GRA.Domain.Service
 
         public async Task RemoveTaskAsync(int taskId)
         {
-            if (await HasPermission(Permission.EditChallenges))
+            if (HasPermission(Permission.EditChallenges))
             {
                 await _challengeTaskRepository
-                    .RemoveSaveAsync(await GetClaimId(ClaimType.UserId), taskId);
+                    .RemoveSaveAsync(GetClaimId(ClaimType.UserId), taskId);
             }
             else
             {
-                int userId = await GetClaimId(ClaimType.UserId);
+                int userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to remove a challenge task");
                 throw new Exception("Permission denied.");
             }
@@ -133,13 +130,13 @@ namespace GRA.Domain.Service
 
         public async Task DecreaseTaskPositionAsync(int taskId)
         {
-            if (await HasPermission(Permission.EditChallenges))
+            if (HasPermission(Permission.EditChallenges))
             {
                 await _challengeTaskRepository.DecreasePositionAsync(taskId);
             }
             else
             {
-                int userId = await GetClaimId(ClaimType.UserId);
+                int userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to modify a challenge task");
                 throw new Exception("Permission denied.");
             }
@@ -147,13 +144,13 @@ namespace GRA.Domain.Service
 
         public async Task IncreaseTaskPositionAsync(int taskId)
         {
-            if (await HasPermission(Permission.EditChallenges))
+            if (HasPermission(Permission.EditChallenges))
             {
                 await _challengeTaskRepository.IncreasePositionAsync(taskId);
             }
             else
             {
-                int userId = await GetClaimId(ClaimType.UserId);
+                int userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to modify a challenge task");
                 throw new Exception("Permission denied.");
             }

--- a/src/GRA.Domain.Service/MailService.cs
+++ b/src/GRA.Domain.Service/MailService.cs
@@ -20,14 +20,14 @@ namespace GRA.Domain.Service
 
         public async Task<int> GetUserUnreadCountAsync()
         {
-            var userId = await GetClaimId(ClaimType.UserId);
+            var userId = GetClaimId(ClaimType.UserId);
             return await _mailRepository.GetUserUnreadCountAsync(userId);
         }
 
         public async Task<DataWithCount<IEnumerable<Mail>>> GetUserPaginatedAsync(int skip,
             int take)
         {
-            var userId = await GetClaimId(ClaimType.UserId);
+            var userId = GetClaimId(ClaimType.UserId);
             var dataTask = _mailRepository.PageUserAsync(userId, skip, take);
             var countTask = _mailRepository.GetUserCountAsync(userId);
             await Task.WhenAll(dataTask, countTask);
@@ -43,7 +43,7 @@ namespace GRA.Domain.Service
             int skip,
             int take)
         {
-            if (await HasPermission(Permission.ReadAllMail))
+            if (HasPermission(Permission.ReadAllMail))
             {
                 var dataTask = _mailRepository.PageUserAsync(getMailForUserId, skip, take);
                 var countTask = _mailRepository.GetUserCountAsync(getMailForUserId);
@@ -56,7 +56,7 @@ namespace GRA.Domain.Service
             }
             else
             {
-                var requestingUser = await GetClaimId(ClaimType.UserId);
+                var requestingUser = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {requestingUser} doesn't have permission to view messages for {getMailForUserId}.");
                 throw new Exception("Permission denied.");
             }
@@ -64,8 +64,8 @@ namespace GRA.Domain.Service
 
         public async Task<Mail> GetDetails(int mailId)
         {
-            var userId = await GetClaimId(ClaimType.UserId);
-            bool canReadAll = await HasPermission(Permission.ReadAllMail);
+            var userId = GetClaimId(ClaimType.UserId);
+            bool canReadAll = HasPermission(Permission.ReadAllMail);
             var mail = await _mailRepository.GetByIdAsync(mailId);
             if (mail.FromUserId == userId || mail.ToUserId == userId || canReadAll)
             {
@@ -78,8 +78,8 @@ namespace GRA.Domain.Service
         public async Task<DataWithCount<IEnumerable<Mail>>> GetAllPaginatedAsync(int skip,
             int take)
         {
-            int siteId = await GetClaimId(ClaimType.SiteId);
-            if (await HasPermission(Permission.ReadAllMail))
+            int siteId = GetClaimId(ClaimType.SiteId);
+            if (HasPermission(Permission.ReadAllMail))
             {
                 var dataTask = _mailRepository.PageAllAsync(siteId, skip, take);
                 var countTask = _mailRepository.GetAllCountAsync();
@@ -92,7 +92,7 @@ namespace GRA.Domain.Service
             }
             else
             {
-                var userId = await GetClaimId(ClaimType.UserId);
+                var userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to get all mails.");
                 throw new Exception("Permission denied.");
             }
@@ -101,7 +101,7 @@ namespace GRA.Domain.Service
         public async Task<DataWithCount<IEnumerable<Mail>>> GetAllUnreadPaginatedAsync(int skip,
             int take)
         {
-            if (await HasPermission(Permission.ReadAllMail))
+            if (HasPermission(Permission.ReadAllMail))
             {
                 var dataTask = _mailRepository.PageAdminUnreadAsync(skip, take);
                 var countTask = _mailRepository.GetAdminUnreadCountAsync();
@@ -114,7 +114,7 @@ namespace GRA.Domain.Service
             }
             else
             {
-                var userId = await GetClaimId(ClaimType.UserId);
+                var userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to get all unread mails.");
                 throw new Exception("Permission denied.");
             }
@@ -122,7 +122,7 @@ namespace GRA.Domain.Service
 
         public async Task MarkAsReadAsync(int mailId)
         {
-            var userId = await GetClaimId(ClaimType.UserId);
+            var userId = GetClaimId(ClaimType.UserId);
             var mail = await _mailRepository.GetByIdAsync(mailId);
             if (mail.FromUserId == userId || mail.ToUserId == userId)
             {
@@ -136,17 +136,17 @@ namespace GRA.Domain.Service
         public async Task<Mail> SendAsync(Mail mail)
         {
             if (mail.ToUserId == null
-               || await HasPermission(Permission.MailParticipants))
+               || HasPermission(Permission.MailParticipants))
             {
-                mail.FromUserId = await GetClaimId(ClaimType.UserId);
+                mail.FromUserId = GetClaimId(ClaimType.UserId);
                 mail.IsNew = true;
                 mail.IsDeleted = false;
-                mail.SiteId = await GetClaimId(ClaimType.SiteId);
+                mail.SiteId = GetClaimId(ClaimType.SiteId);
                 return await _mailRepository.AddSaveAsync(mail.FromUserId, mail);
             }
             else
             {
-                var userId = await GetClaimId(ClaimType.UserId);
+                var userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to send a mail to {mail.ToUserId}.");
                 throw new Exception("Permission denied");
             }
@@ -155,20 +155,20 @@ namespace GRA.Domain.Service
         public async Task<Mail> SendReplyAsync(Mail mail, int inReplyToId)
         {
             if (mail.ToUserId == null
-               || await HasPermission(Permission.MailParticipants))
+               || HasPermission(Permission.MailParticipants))
             {
                 var inReplyToMail = await _mailRepository.GetByIdAsync(inReplyToId);
                 mail.InReplyToId = inReplyToId;
                 mail.ThreadId = inReplyToMail.ThreadId ?? inReplyToId;
-                mail.FromUserId = await GetClaimId(ClaimType.UserId);
+                mail.FromUserId = GetClaimId(ClaimType.UserId);
                 mail.IsNew = true;
                 mail.IsDeleted = false;
-                mail.SiteId = await GetClaimId(ClaimType.SiteId);
+                mail.SiteId = GetClaimId(ClaimType.SiteId);
                 return await _mailRepository.AddSaveAsync(mail.FromUserId, mail);
             }
             else
             {
-                var userId = await GetClaimId(ClaimType.UserId);
+                var userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to send a mail to {mail.ToUserId}.");
                 throw new Exception("Permission denied");
             }
@@ -177,8 +177,8 @@ namespace GRA.Domain.Service
 
         public async Task RemoveAsync(int mailId)
         {
-            var userId = await GetClaimId(ClaimType.UserId);
-            bool canDeleteAll = await HasPermission(Permission.DeleteAnyMail);
+            var userId = GetClaimId(ClaimType.UserId);
+            bool canDeleteAll = HasPermission(Permission.DeleteAnyMail);
             var mail = await _mailRepository.GetByIdAsync(mailId);
             if (mail.FromUserId == userId || mail.ToUserId == userId || canDeleteAll)
             {

--- a/src/GRA.Domain.Service/SiteService.cs
+++ b/src/GRA.Domain.Service/SiteService.cs
@@ -31,7 +31,7 @@ namespace GRA.Domain.Service
         public async Task<IEnumerable<Model.System>> GetSystemList()
         {
             
-            return await _systemRepository.GetAllAsync(await GetCurrentSiteId());
+            return await _systemRepository.GetAllAsync(GetCurrentSiteId());
         }
 
         public async Task<IEnumerable<Branch>> GetBranches(int systemId)
@@ -41,7 +41,7 @@ namespace GRA.Domain.Service
 
         public async Task<IEnumerable<Program>> GetProgramList()
         {
-            return await _programRepository.GetAllAsync(await GetCurrentSiteId());
+            return await _programRepository.GetAllAsync(GetCurrentSiteId());
         }
     }
 }

--- a/src/GRA.Domain.Service/UserService.cs
+++ b/src/GRA.Domain.Service/UserService.cs
@@ -52,8 +52,8 @@ namespace GRA.Domain.Service
         public async Task<DataWithCount<IEnumerable<User>>>
            GetPaginatedUserListAsync(int skip, int take)
         {
-            int siteId = await GetClaimId(ClaimType.SiteId);
-            if (await HasPermission(Permission.ViewParticipantList))
+            int siteId = GetClaimId(ClaimType.SiteId);
+            if (HasPermission(Permission.ViewParticipantList))
             {
                 var dataTask = _userRepository.PageAllAsync(siteId, skip, take);
                 var countTask = _userRepository.GetCountAsync();
@@ -66,7 +66,7 @@ namespace GRA.Domain.Service
             }
             else
             {
-                int userId = await GetClaimId(ClaimType.UserId);
+                int userId = GetClaimId(ClaimType.UserId);
                 _logger.LogError($"User {userId} doesn't have permission to view all participants.");
                 throw new Exception("Permission denied.");
             }
@@ -78,9 +78,9 @@ namespace GRA.Domain.Service
             int skip,
             int take)
         {
-            int requestingUserId = await GetClaimId(ClaimType.UserId);
+            int requestingUserId = GetClaimId(ClaimType.UserId);
             if (requestingUserId == householdHeadUserId
-                || await HasPermission(Permission.ViewParticipantList))
+                || HasPermission(Permission.ViewParticipantList))
             {
                 var dataTask = _userRepository.PageHouseholdAsync(householdHeadUserId, skip, take);
                 var countTask = _userRepository.GetHouseholdCountAsync(householdHeadUserId);
@@ -101,9 +101,9 @@ namespace GRA.Domain.Service
         public async Task<int>
             FamilyMemberCountAsync(int householdHeadUserId)
         {
-            int requestingUserId = await GetClaimId(ClaimType.UserId);
+            int requestingUserId = GetClaimId(ClaimType.UserId);
             if (requestingUserId == householdHeadUserId
-                || await HasPermission(Permission.ViewParticipantList))
+                || HasPermission(Permission.ViewParticipantList))
             {
                 return await _userRepository.GetHouseholdCountAsync(householdHeadUserId);
             }
@@ -116,13 +116,13 @@ namespace GRA.Domain.Service
 
         public async Task<User> GetDetails(int userId)
         {
-            int requestingUserId = await GetActiveUserId();
+            int requestingUserId = GetActiveUserId();
             var requestingUser = await _userRepository.GetByIdAsync(requestingUserId);
-            int authUserId = await GetClaimId(ClaimType.UserId);
+            int authUserId = GetClaimId(ClaimType.UserId);
 
             if (requestingUserId == userId
                 || requestingUser.HouseholdHeadUserId == authUserId
-                || await HasPermission(Permission.ViewParticipantDetails))
+                || HasPermission(Permission.ViewParticipantDetails))
             {
                 return await _userRepository.GetByIdAsync(userId);
             }
@@ -135,7 +135,7 @@ namespace GRA.Domain.Service
 
         public async Task<User> Update(User userToUpdate)
         {
-            int requestingUserId = await GetActiveUserId();
+            int requestingUserId = GetActiveUserId();
 
             if (requestingUserId == userToUpdate.Id)
             {
@@ -166,9 +166,9 @@ namespace GRA.Domain.Service
 
         public async Task<User> MCUpdate(User userToUpdate)
         {
-            int requestedByUserId = await GetClaimId(ClaimType.UserId);
+            int requestedByUserId = GetClaimId(ClaimType.UserId);
 
-            if (await HasPermission(Permission.EditParticipants))
+            if (HasPermission(Permission.EditParticipants))
             {
                 // admin users can update anything except siteid
                 var currentEntity = await _userRepository.GetByIdAsync(userToUpdate.Id);
@@ -184,9 +184,9 @@ namespace GRA.Domain.Service
 
         public async Task Remove(int userIdToRemove)
         {
-            int requestedByUserId = await GetClaimId(ClaimType.UserId);
+            int requestedByUserId = GetClaimId(ClaimType.UserId);
 
-            if (await HasPermission(Permission.DeleteParticipants))
+            if (HasPermission(Permission.DeleteParticipants))
             {
                 var userLookup = await _userRepository.GetByIdAsync(userIdToRemove);
                 if (!userLookup.CanBeDeleted)
@@ -212,9 +212,9 @@ namespace GRA.Domain.Service
             int skip,
             int take)
         {
-            int requestedByUserId = await GetActiveUserId();
+            int requestedByUserId = GetActiveUserId();
             if (requestedByUserId == userId
-               || await HasPermission(Permission.ViewParticipantDetails))
+               || HasPermission(Permission.ViewParticipantDetails))
             {
                 return new DataWithCount<IEnumerable<UserLog>>
                 {
@@ -232,9 +232,9 @@ namespace GRA.Domain.Service
         public async Task<DataWithCount<IEnumerable<Book>>>
             GetPaginatedUserBookListAsync(int userId, int skip, int take)
         {
-            int requestedByUserId = await GetActiveUserId();
+            int requestedByUserId = GetActiveUserId();
             if (requestedByUserId == userId
-               || await HasPermission(Permission.ViewParticipantDetails))
+               || HasPermission(Permission.ViewParticipantDetails))
             {
                 var dataTask = _bookRepository.GetForUserAsync(userId);
                 var countTask = _bookRepository.GetCountForUserAsync(userId);
@@ -255,7 +255,7 @@ namespace GRA.Domain.Service
         public async Task<string>
             ActivateAuthorizationCode(string authorizationCode)
         {
-            int siteId = await GetClaimId(ClaimType.SiteId);
+            int siteId = GetClaimId(ClaimType.SiteId);
             var authCode
                 = await _authorizationCodeRepository.GetByCodeAsync(siteId, authorizationCode);
 
@@ -263,7 +263,7 @@ namespace GRA.Domain.Service
             {
                 return null;
             }
-            int userId = await GetClaimId(ClaimType.UserId);
+            int userId = GetClaimId(ClaimType.UserId);
             await _userRepository.AddRoleAsync(userId, userId, authCode.RoleId);
             if (authCode.IsSingleUse)
             {

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -111,7 +111,7 @@ namespace GRA.Web
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            if (env.IsDevelopment())
+            if (env.IsDevelopment() && false)
             {
                 app.UseDeveloperExceptionPage();
                 app.UseBrowserLink();

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using GRA.Domain.Service;
 
 namespace GRA.Web
 {
@@ -73,16 +74,19 @@ namespace GRA.Web
             services.AddScoped<Domain.Service.Abstract.IUserContextProvider, Controllers.UserContextProvider>();
             services.AddScoped<Security.Abstract.IPasswordHasher, Security.PasswordHasher>();
 
+            // filters
+            services.AddScoped<Controllers.Filter.SiteFilter>();
+
             // services
-            services.AddScoped<Domain.Service.ActivityService, Domain.Service.ActivityService>();
-            services.AddScoped<Domain.Service.AuthenticationService, Domain.Service.AuthenticationService>();
-            services.AddScoped<Domain.Service.ChallengeService, Domain.Service.ChallengeService>();
-            services.AddScoped<Domain.Service.InitialSetupService, Domain.Service.InitialSetupService>();
-            services.AddScoped<Domain.Service.MailService, Domain.Service.MailService>();
-            services.AddScoped<Domain.Service.SampleDataService, Domain.Service.SampleDataService>();
-            services.AddScoped<Domain.Service.SiteLookupService, Domain.Service.SiteLookupService>();
-            services.AddScoped<Domain.Service.SiteService, Domain.Service.SiteService>();
-            services.AddScoped<Domain.Service.UserService, Domain.Service.UserService>();
+            services.AddScoped<ActivityService>();
+            services.AddScoped<AuthenticationService>();
+            services.AddScoped<ChallengeService>();
+            services.AddScoped<InitialSetupService>();
+            services.AddScoped<MailService>();
+            services.AddScoped<SampleDataService>();
+            services.AddScoped<SiteLookupService>();
+            services.AddScoped<SiteService>();
+            services.AddScoped<UserService>();
 
             // repositories
             services.AddScoped<Domain.Repository.IAuthorizationCodeRepository, Data.Repository.AuthorizationCodeRepository>();
@@ -136,6 +140,7 @@ namespace GRA.Web
                 AutomaticChallenge = true
             });
 
+            // sitePath is also referenced in GRA.Controllers.Filter.SiteFilter
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/src/GRA.Web/project.json
+++ b/src/GRA.Web/project.json
@@ -5,7 +5,7 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Razor.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.1.0-preview4-final",
       "type": "build"
     },
     "GRA.Domain.Model": "1.0.0-*",
@@ -28,7 +28,6 @@
     "Microsoft.Extensions.Logging.Debug": "1.1.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.1.0",
-    "BundlerMinifier.Core": "2.2.306",
     "GRA.Security": "1.0.0-*",
     "Microsoft.AspNetCore.Authentication.Cookies": "1.1.0",
     "Microsoft.Extensions.Caching.Memory": "1.1.0",
@@ -37,7 +36,8 @@
 
   "tools": {
     "Microsoft.AspNetCore.Razor.Tools": "1.1.0-preview4-final",
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.1.0-preview4-final"
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.1.0-preview4-final",
+    "BundlerMinifier.Core": "2.2.306"
   },
 
   "frameworks": {

--- a/src/GRA.Web/wwwroot/js/site.min.js
+++ b/src/GRA.Web/wwwroot/js/site.min.js
@@ -1,0 +1,1 @@
+$(".btn-spinner").on("click",function(n){$(this).parents("form:first").valid()&&(n.preventDefault(),$(this).hasClass("disabled")||($(this).addClass("disabled"),$(this).children(".fa-spinner").removeClass("hidden"),$(this).parents("form:first").submit()))});


### PR DESCRIPTION
- Redirect timed-out sessions to the sign in page
- Remove the need for a user to re-authenticate after entering an
  authorization code.
- Move site and sitePath handling into resource filter
- Remove async from `UserContext`-related calls