### PR TITLE
Add email signup and calendar reminder prior to registration open

### DIFF
--- a/src/GRA.Controllers/Base/Controller.cs
+++ b/src/GRA.Controllers/Base/Controller.cs
@@ -136,13 +136,13 @@ namespace GRA.Controllers.Base
             return new UserClaimLookup(AuthUser).GetId(claimType);
         }
 
-        protected int GetCurrentSiteId(string sitePath)
+        protected int GetCurrentSiteId(string sitePath = null)
         {
             var context = _userContextProvider.GetContext();
             return context.SiteId;
         }
 
-        protected async Task<Site> GetCurrentSite(string sitePath)
+        protected async Task<Site> GetCurrentSiteAsync(string sitePath = null)
         {
             return await _siteLookupService.GetById(GetCurrentSiteId(sitePath));
         }

--- a/src/GRA.Controllers/JoinController.cs
+++ b/src/GRA.Controllers/JoinController.cs
@@ -35,7 +35,7 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Index(string sitePath = null)
         {
-            var site = await GetCurrentSite(sitePath);
+            var site = await GetCurrentSiteAsync(sitePath);
             PageTitle = $"{site.Name} - Join Now!";
 
             var branchList = await _siteService.GetBranches(1);
@@ -51,7 +51,7 @@ namespace GRA.Controllers
         [HttpPost]
         public async Task<IActionResult> Index(JoinViewModel model, string sitePath = null)
         {
-            var site = await GetCurrentSite(sitePath);
+            var site = await GetCurrentSiteAsync(sitePath);
 
             if (ModelState.IsValid)
             {

--- a/src/GRA.Controllers/MissionControl/HomeController.cs
+++ b/src/GRA.Controllers/MissionControl/HomeController.cs
@@ -49,7 +49,7 @@ namespace GRA.Controllers.MissionControl
                 // not authorized for Mission Control, redirect to authorization code
                 return View("AuthorizationCode");
             }
-            Site site = await GetCurrentSite(sitePath);
+            Site site = await GetCurrentSiteAsync(sitePath);
             PageTitle = $"Mission Control: {site.Name}";
             return View();
         }

--- a/src/GRA.Controllers/SignInController.cs
+++ b/src/GRA.Controllers/SignInController.cs
@@ -26,7 +26,7 @@ namespace GRA.Controllers
 
         public async Task<IActionResult> Index(string sitePath = null, string ReturnUrl = null)
         {
-            var site = await GetCurrentSite(sitePath);
+            var site = await GetCurrentSiteAsync(sitePath);
             PageTitle = $"Sign In to {site.Name}";
 
             SignInViewModel viewModel = new SignInViewModel();

--- a/src/GRA.Controllers/ViewModel/Home/NotOpenYetViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Home/NotOpenYetViewModel.cs
@@ -1,0 +1,16 @@
+﻿using GRA.Domain.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GRA.Controllers.ViewModel.Home
+{
+    public class NotOpenYetViewModel
+    {
+        public Site Site { get; set; }
+        public string RegistrationOpens { get; set; }
+        public string Email { get; set; }
+        public string SignUpSource { get; set; }
+    }
+}

--- a/src/GRA.Data/AuditingRepository.cs
+++ b/src/GRA.Data/AuditingRepository.cs
@@ -143,6 +143,14 @@ namespace GRA.Data
             return _mapper.Map<DbEntity, DomainEntity>(dbEntity);
         }
 
+        public virtual async Task<DomainEntity> AddSaveNoAuditAsync(DomainEntity domainEntity)
+        {
+            var dbEntity = _mapper.Map<DbEntity>(domainEntity);
+            await DbSet.AddAsync(dbEntity);
+            await SaveAsync();
+            return await GetByIdAsync(dbEntity.Id);
+        }
+
         protected virtual async Task AddAsync(int userId, DbEntity dbEntity)
         {
             dbEntity.CreatedBy = userId;

--- a/src/GRA.Data/Context.cs
+++ b/src/GRA.Data/Context.cs
@@ -49,6 +49,9 @@ namespace GRA.Data
 
             // add indexing as needed
             // https://docs.microsoft.com/en-us/ef/core/modeling/indexes
+            modelBuilder.Entity<Model.EmailReminder>()
+                .HasIndex(_ => new { _.Email, _.SignUpSource })
+                .IsUnique();
             modelBuilder.Entity<Model.Notification>()
                 .HasIndex(_ => _.UserId);
             modelBuilder.Entity<Model.Page>()
@@ -79,6 +82,7 @@ namespace GRA.Data
         public DbSet<Model.Challenge> Challenges { get; set; }
         public DbSet<Model.ChallengeTask> ChallengeTasks { get; set; }
         public DbSet<Model.ChallengeTaskType> ChallengeTaskTypes { get; set; }
+        public DbSet<Model.EmailReminder> EmailReminders { get; set; }
         public DbSet<Model.Mail> Mails { get; set; }
         public DbSet<Model.Notification> Notifications { get; set; }
         public DbSet<Model.Page> Pages { get; set; }

--- a/src/GRA.Data/Model/EmailReminder.cs
+++ b/src/GRA.Data/Model/EmailReminder.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Data.Model
+{
+    public class EmailReminder : Abstract.BaseDbEntity
+    {
+        [Required]
+        public string Email { get; set; }
+        [Required]
+        public string SignUpSource { get; set; }
+    }
+}

--- a/src/GRA.Data/Model/Site.cs
+++ b/src/GRA.Data/Model/Site.cs
@@ -40,5 +40,8 @@ namespace GRA.Data.Model
 
         public string ExternalEventListUrl { get; set; }
         public string GoogleAnalyticsTrackingId { get; set; }
+        public bool CollectPreregistrationEmails { get; set; }
+        [MaxLength(150)]
+        public string MetaDescription { get; set; }
     }
 }

--- a/src/GRA.Data/Profile/MappingProfile.cs
+++ b/src/GRA.Data/Profile/MappingProfile.cs
@@ -10,6 +10,7 @@
             CreateMap<Model.Branch, Domain.Model.Branch>().ReverseMap();
             CreateMap<Model.Challenge, Domain.Model.Challenge>().ReverseMap();
             CreateMap<Model.ChallengeTask, Domain.Model.ChallengeTask>().ReverseMap();
+            CreateMap<Model.EmailReminder, Domain.Model.EmailReminder>().ReverseMap();
             CreateMap<Model.Mail, Domain.Model.Mail>().ReverseMap();
             CreateMap<Model.Notification, Domain.Model.Notification>().ReverseMap();
             CreateMap<Model.Page, Domain.Model.Page>().ReverseMap();

--- a/src/GRA.Data/Repository/EmailReminderRepository.cs
+++ b/src/GRA.Data/Repository/EmailReminderRepository.cs
@@ -1,0 +1,31 @@
+﻿using GRA.Domain.Repository;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GRA.Data.ServiceFacade;
+using Microsoft.Extensions.Logging;
+using GRA.Domain.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace GRA.Data.Repository
+{
+    public class EmailReminderRepository
+        : AuditingRepository<Model.EmailReminder, Domain.Model.EmailReminder>,
+        IEmailReminderRepository
+    {
+        public EmailReminderRepository(ServiceFacade.Repository repositoryFacade,
+            ILogger<EmailReminderRepository> logger) : base(repositoryFacade, logger)
+        {
+        }
+
+        public async Task<bool> ExistsEmailSourceAsync(string emailAddress, string signUpSource)
+        {
+            var lookup = await DbSet
+                .AsNoTracking()
+                .Where(_ => _.Email == emailAddress && _.SignUpSource == signUpSource)
+                .SingleOrDefaultAsync();
+            return lookup != null;
+        }
+    }
+}

--- a/src/GRA.Domain.Model/EmailReminder.cs
+++ b/src/GRA.Domain.Model/EmailReminder.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Domain.Model
+{
+    public class EmailReminder : Abstract.BaseDomainEntity
+    {
+        [Required]
+        public string Email { get; set; }
+        [Required]
+        public string SignUpSource { get; set; }
+    }
+}

--- a/src/GRA.Domain.Model/Site.cs
+++ b/src/GRA.Domain.Model/Site.cs
@@ -36,5 +36,8 @@ namespace GRA.Domain.Model
 
         public string ExternalEventListUrl { get; set; }
         public string GoogleAnalyticsTrackingId { get; set; }
+        public bool CollectPreregistrationEmails { get; set; }
+        [MaxLength(150)]
+        public string MetaDescription { get; set; }
     }
 }

--- a/src/GRA.Domain.Repository/IEmailReminderRepository.cs
+++ b/src/GRA.Domain.Repository/IEmailReminderRepository.cs
@@ -1,0 +1,13 @@
+﻿using GRA.Domain.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GRA.Domain.Repository
+{
+    public interface IEmailReminderRepository : IRepository<EmailReminder>
+    {
+        Task<bool> ExistsEmailSourceAsync(string emailAddress, string signUpSource);
+    }
+}

--- a/src/GRA.Domain.Repository/IRepository.cs
+++ b/src/GRA.Domain.Repository/IRepository.cs
@@ -8,6 +8,7 @@ namespace GRA.Domain.Repository
     {
         Task AddAsync(int currentUserId, DomainEntity entity);
         Task<DomainEntity> AddSaveAsync(int currentUserId, DomainEntity entity);
+        Task<DomainEntity> AddSaveNoAuditAsync(DomainEntity entity);
         Task<DomainEntity> GetByIdAsync(int id);
         Task RemoveSaveAsync(int currentUserId, int id);
         Task SaveAsync();

--- a/src/GRA.Domain.Service/EmailReminderService.cs
+++ b/src/GRA.Domain.Service/EmailReminderService.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using GRA.Domain.Repository;
+
+namespace GRA.Domain.Service
+{
+    public class EmailReminderService : Abstract.BaseService<EmailReminderService>
+    {
+        private readonly IEmailReminderRepository _emailReminderRepository;
+        public EmailReminderService(ILogger<EmailReminderService> logger,
+            IEmailReminderRepository emailReminderRepository) : base(logger)
+        {
+            _emailReminderRepository = Require.IsNotNull(emailReminderRepository,
+                nameof(emailReminderRepository));
+        }
+
+        public async Task AddEmailReminderAsync(string email, string signUpSource)
+        {
+            if (string.IsNullOrEmpty(email))
+            {
+                throw new ArgumentNullException(nameof(email));
+            }
+            if (string.IsNullOrEmpty(signUpSource))
+            {
+                throw new ArgumentNullException(nameof(signUpSource));
+            }
+            var alreadySubscribed 
+                = await _emailReminderRepository.ExistsEmailSourceAsync(email, signUpSource);
+            if (!alreadySubscribed)
+            {
+                await _emailReminderRepository.AddSaveNoAuditAsync(new Model.EmailReminder
+                {
+                    CreatedAt = DateTime.Now,
+                    Email = email,
+                    SignUpSource = signUpSource
+                });
+            }
+        }
+    }
+}

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -131,6 +131,7 @@ namespace GRA.Web
             services.AddScoped<AuthenticationService>();
             services.AddScoped<BadgeService>();
             services.AddScoped<ChallengeService>();
+            services.AddScoped<EmailReminderService>();
             services.AddScoped<EmailService>();
             services.AddScoped<InitialSetupService>();
             services.AddScoped<MailService>();
@@ -147,6 +148,7 @@ namespace GRA.Web
             services.AddScoped<Domain.Repository.IBranchRepository, Data.Repository.BranchRepository>();
             services.AddScoped<Domain.Repository.IChallengeRepository, Data.Repository.ChallengeRepository>();
             services.AddScoped<Domain.Repository.IChallengeTaskRepository, Data.Repository.ChallengeTaskRepository>();
+            services.AddScoped<Domain.Repository.IEmailReminderRepository, Data.Repository.EmailReminderRepository>();
             services.AddScoped<Domain.Repository.IMailRepository, Data.Repository.MailRepository>();
             services.AddScoped<Domain.Repository.INotificationRepository, Data.Repository.NotificationRepository>();
             services.AddScoped<Domain.Repository.IPageRepository, Data.Repository.PageRepository>();

--- a/src/GRA.Web/Views/Home/IndexNotOpenYet.cshtml
+++ b/src/GRA.Web/Views/Home/IndexNotOpenYet.cshtml
@@ -43,11 +43,20 @@
                     <div class="input-group">
                         <input asp-for="Email" class="form-control" type="email" autofocus />
                         <span class="input-group-btn">
-                            <button type="submit" 
-                                    class="btn btn-info"><span class="fa fa-envelope-o"></span> Remind me!</button>
+                            <button type="submit"
+                                    class="btn btn-info">
+                                <span class="fa fa-envelope-o"></span> Remind me!
+                            </button>
                         </span>
                     </div>
                 </div>
+            </form>
+            <p><strong>Want to add a calendar reminder?</strong> Click "Add to calendar" button!</p>
+            <form asp-controller="Home"
+                  asp-action="GetIcs"
+                  method="post"
+                  role="form">
+                <button type="submit" class="btn btn-primary center-block"><span class="fa fa-calendar"></span> Add to calendar</button>
             </form>
         }
         else

--- a/src/GRA.Web/Views/Home/IndexNotOpenYet.cshtml
+++ b/src/GRA.Web/Views/Home/IndexNotOpenYet.cshtml
@@ -1,4 +1,6 @@
-﻿<div class="row" style="margin-bottom: 1em;">
+﻿@model GRA.Controllers.ViewModel.Home.NotOpenYetViewModel
+
+<div class="row" style="margin-bottom: 1em;">
     <div class="col-xs-12">
         <img src="~/images/meadow.jpg"
              alt="Illustration of a meadow."
@@ -17,10 +19,41 @@
         </p>
     </div>
     <div class="col-sm-6">
-        <p>
-            Welcome to <grasite property="name"></grasite>. Soon you'll be able to join the program
-            right here! Come back soon!
-        </p>
+        Welcome to <grasite property="name"></grasite>.
+        @if (Model == null || Model.Site == null || string.IsNullOrEmpty(Model.RegistrationOpens))
+            {
+            <p>When the program starts, you'll be able to join right here. Come back soon!</p>
+        }
+        else if (Model.Site.CollectPreregistrationEmails == true)
+        {
+            <p>You can join our program starting on @Model.RegistrationOpens!</p>
+
+            <p>
+                <strong>Would you like a reminder email?</strong> Enter your email address below
+                and click the "Remind me" button and we'll send you a reminder when you can join.
+            </p>
+            <form asp-controller="Home"
+                  asp-action="AddReminder"
+                  method="post"
+                  role="form"
+                  class="form-horizontal">
+                <input asp-for="SignUpSource" type="hidden" />
+                <div class="form-group" style="padding: 0.5em 1em;">
+                    <label asp-for="Email" class="control-label sr-only"></label>
+                    <div class="input-group">
+                        <input asp-for="Email" class="form-control" type="email" autofocus />
+                        <span class="input-group-btn">
+                            <button type="submit" 
+                                    class="btn btn-info"><span class="fa fa-envelope-o"></span> Remind me!</button>
+                        </span>
+                    </div>
+                </div>
+            </form>
+        }
+        else
+        {
+            <p>You can join our program starting on @Model.RegistrationOpens!</p>
+        }
     </div>
     <div class="col-sm-3">
         <p>Reading for 20 minutes a day helps build a strong lifelong reading habit.</p>

--- a/src/GRA.Web/Views/Shared/_Layout.cshtml
+++ b/src/GRA.Web/Views/Shared/_Layout.cshtml
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData[GRA.Controllers.ViewDataKey.Title]</title>
     <environment names="Development">
@@ -138,17 +139,19 @@
     @if (Context.Items["GoogleAnalyticsTrackingId"] != null)
     {
         <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-          ga('create', '@Context.Items["GoogleAnalyticsTrackingId"].ToString()', 'auto');
-          ga('send', 'pageview');
+            (function (i, s, o, g, r, a, m) {
+                i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+                    (i[r].q = i[r].q || []).push(arguments)
+                }, i[r].l = 1 * new Date(); a = s.createElement(o),
+                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+            })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+            ga('create', '@Context.Items["GoogleAnalyticsTrackingId"].ToString()', 'auto');
+            ga('send', 'pageview');
         </script>
     }
     @RenderSection("scripts", required: false)
     <script>
-        $(function() {
+        $(function () {
             $('[data-toggle="tooltip"]').tooltip()
         })
     </script>


### PR DESCRIPTION
- :card_index: Includes database changes
- Rename `GetCurrentSite` to `GetCurrentSiteAsync`
- Add non-audit add method to `AuditingRepository`
- Add email reminder objects, repo, service
- Add email form to not-open-yet view
- Add `MetaDescription` field to site - not yet implemented
- Show registration open date on homepage if available
- Add `X-UA-Compatible` header for IE
- Add ICS file download to not open yet view