### PR TITLE
Fix EF migration error, CDN content

### DIFF
--- a/src/GRA.Web/Areas/MissionControl/Views/Shared/_Layout.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Shared/_Layout.cshtml
@@ -135,12 +135,12 @@
                 asp-fallback-test="window.jQuery"
                 asp-append-version="true">
         </script>
-        <script src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"
+        <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"
                 asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
                 asp-fallback-test="window.jQuery"
                 asp-append-version="true">
         </script>
-        <script src="http://ajax.aspnetcdn.com/ajax/mvc/5.2.3/jquery.validate.unobtrusive.min.js"
+        <script src="https://ajax.aspnetcdn.com/ajax/mvc/5.2.3/jquery.validate.unobtrusive.min.js"
                 asp-fallback-src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
                 asp-fallback-test="window.jQuery"
                 asp-append-version="true">

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -68,7 +68,7 @@ namespace GRA.Web
 
             string contentDirectory = Configuration[ConfigurationKey.ContentDirectory];
 
-            if (!Directory.Exists(contentDirectory))
+            if (!string.IsNullOrEmpty(contentDirectory) && !Directory.Exists(contentDirectory))
             {
                 try
                 {


### PR DESCRIPTION
- `Startup.cs` was trying to make an empty directory
- Ensure all CDN content comes via https