### PR TITLE
Add badge filenames to paginated challenge lists, bug fixes

### DIFF
--- a/src/GRA.Controllers/SignInController.cs
+++ b/src/GRA.Controllers/SignInController.cs
@@ -75,17 +75,23 @@ namespace GRA.Controllers
         [HttpPost]
         public async Task<IActionResult> ForgotPassword(string username)
         {
-            try
+            if (string.IsNullOrWhiteSpace(username))
             {
-                string recoveryUrl = Url.Action("PasswordRecovery", "SignIn", null, HttpContext.Request.Scheme);
-                await _authenticationService.GenerateTokenAndEmail(username, recoveryUrl);
-                AlertSuccess = $"A password recovery email has been sent to the email of '{username}'";
+                ModelState.AddModelError("", "The Username field is required");
             }
-            catch (GraException gex)
+            if (ModelState.IsValid)
             {
-                ShowAlertWarning("Could not recover password:", gex);
+                try
+                {
+                    string recoveryUrl = Url.Action("PasswordRecovery", "SignIn", null, HttpContext.Request.Scheme);
+                    await _authenticationService.GenerateTokenAndEmail(username, recoveryUrl);
+                    AlertSuccess = $"A password recovery email has been sent to the email of '{username}'";
+                }
+                catch (GraException gex)
+                {
+                    ShowAlertWarning("Could not recover password:", gex);
+                }
             }
-
             return View();
         }
 
@@ -97,14 +103,21 @@ namespace GRA.Controllers
         [HttpPost]
         public async Task<IActionResult> ForgotUsername(string email)
         {
-            try
+            if (string.IsNullOrWhiteSpace(email))
             {
-                await _authenticationService.EmailAllUsernames(email);
-                AlertSuccess = $"A list of usernames associated with {email} has been emailed to you";
+                ModelState.AddModelError("", "The Email field is required");
             }
-            catch (GraException gex)
+            if (ModelState.IsValid)
             {
-                ShowAlertWarning("Could not recover usernames:", gex.Message);
+                try
+                {
+                    await _authenticationService.EmailAllUsernames(email);
+                    AlertSuccess = $"A list of usernames associated with {email} has been emailed to you";
+                }
+                catch (GraException gex)
+                {
+                    ShowAlertWarning("Could not recover usernames:", gex.Message);
+                }
             }
 
             return View();

--- a/src/GRA.Domain.Service/BadgeService.cs
+++ b/src/GRA.Domain.Service/BadgeService.cs
@@ -3,6 +3,7 @@ using GRA.Domain.Repository;
 using GRA.Domain.Service.Abstract;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace GRA.Domain.Service
@@ -45,9 +46,7 @@ namespace GRA.Domain.Service
 
         private string GetUrlPath(string filename)
         {
-            return System.IO.Path.Combine($"site{GetClaimId(ClaimType.SiteId)}",
-                BadgePath,
-                filename);
+            return $"site{GetClaimId(ClaimType.SiteId)}/{BadgePath}/{filename}";
         }
 
         private string WriteBadgeFile(Badge badge, byte[] imageFile)

--- a/src/GRA.Web/Areas/MissionControl/Views/Challenges/Edit.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Challenges/Edit.cshtml
@@ -179,7 +179,7 @@
                 <img class="thumbnail"
                      height="100"
                      width="100"
-                     src="~/@Model.BadgePath"
+                     src="~/@Model.BadgePath?@DateTime.Now.ToString("yyMMddHHmmss")"
                      asp-append-version="true" />
             </div>
         }

--- a/src/GRA.Web/Views/SignIn/ForgotPassword.cshtml
+++ b/src/GRA.Web/Views/SignIn/ForgotPassword.cshtml
@@ -6,6 +6,7 @@
                     <span class="lead"><grasite property="name"></grasite> - Forgot Password</span>
                 </div>
                 <div class="panel-body">
+                    <div asp-validation-summary="All"></div>
                     <div class="row row-spacing">
                         <div class="col-xs-12">
                             <label class="control-label">Username</label>

--- a/src/GRA.Web/Views/SignIn/ForgotUsername.cshtml
+++ b/src/GRA.Web/Views/SignIn/ForgotUsername.cshtml
@@ -6,6 +6,7 @@
                     <span class="lead"><grasite property="name"></grasite> - Username Recovery</span>
                 </div>
                 <div class="panel-body">
+                    <div asp-validation-summary="All"></div>
                     <div class="row row-spacing">
                         <div class="col-xs-12">
                             <label class="control-label">Email Address</label>


### PR DESCRIPTION
- Add handling to account recovery to check if Username/Email fields are left blank
- Add badge filenames to paginated challenge lists
- Fix URL paths to use proper slashes
- Manually cache-bust for challenge badges as the `asp-append-version`
  tag helper doesn't work if the image url is dynamic?