### PR TITLE
change developer setup to include additonal info about migrations

### DIFF
--- a/dev/initial-developer-setup.md
+++ b/dev/initial-developer-setup.md
@@ -27,6 +27,10 @@ Initial database setup and configuration can be done utilizing the `dotnet` comm
 
     `dotnet ef --startup-project ../GRA.Web migrations add initial`
 
+  4. Create or update the database to the migration:
+
+    `dotnet ef --startup-project ../GRA.Web database update`
+
 ### Configuration
 
 The `GRA.Web` project has the [Secret Manager](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets#secret-manager) enabled. You may want to issue a command such as:


### PR DESCRIPTION
The setup process did not include this detail about applying the migrations to the database. I had to run this in order for mine to work. It is possible I am mistaken and this is run automatically at some point. If this is wrong, please correct me.