### PR TITLE
Add Slack logging sink for Serilog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+### Added
+- Slack logging capability (see appsettings.json for configuration)
+
 ## [4.0.0-alpha2] - 2017-03-08
 ### Added
 - Add database fields and front-end display for social.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -77,6 +77,10 @@ The Great Reading Adventure uses open source components. You can find informatio
 - A cross-platform .NET library for IMAP, POP3, and SMTP.
 - Source on GitHub: [jstedfast/MailKit](https://github.com/jstedfast/MailKit) - [MIT License](https://github.com/jstedfast/MailKit/blob/master/License.md)
 
+### Newtonsoft.Json
+- [Json.NET](http://www.newtonsoft.com/json): A high-performance JSON framework for .NET.
+- Source on GitHub: [JamesNK/Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) - [MIT License](https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)
+
 ### PasswordHasher
 - Securely hash passwords for storage in the database and for valiating logins.
 - Adapted code from the [ASP.NET Identity PasswordHasher class](https://github.com/aspnet/Identity/blob/dev/src/Microsoft.AspNetCore.Identity/PasswordHasher.cs)
@@ -85,6 +89,10 @@ The Great Reading Adventure uses open source components. You can find informatio
 ### PageDown
 - Markdown to HTML converter and editor [hg-git clone](http://code.google.com/p/pagedown/)
 - Source on GitHub: [ujifgc/pagedown](https://github.com/ujifgc/pagedown) - [MIT License](https://github.com/ujifgc/pagedown/blob/master/LICENSE.txt)
+
+### Serilog
+- [Serilog](https://serilog.net/): Simple .NET logging with fully-structured events
+- Source on GitHub: [serilog/serilog](https://github.com/serilog/serilog) - [Apache License, Version 2.0](https://github.com/serilog/serilog/blob/dev/LICENSE)
 
 ### Slugify.js
 - Javascript text replacement to slugify strings.

--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -60,6 +60,7 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="1.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.2.0" />
+    <PackageReference Include="Serilog.Sinks.Slack.Core" Version="0.1.2-beta" />
   </ItemGroup>
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish">

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -16,6 +16,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 
 namespace GRA.Web
 {
@@ -49,6 +50,12 @@ namespace GRA.Web
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(Configuration)
                 .CreateLogger();
+
+            Log.Logger.Warning("Great Reading Adventure v{0} starting up in {1}",
+                Assembly.GetEntryAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    .InformationalVersion,
+                env.WebRootPath);
 
             foreach (var configKey in _defaultSettings.Keys)
             {

--- a/src/GRA.Web/appsettings.json
+++ b/src/GRA.Web/appsettings.json
@@ -21,6 +21,13 @@
     "MinimumLevel": "Debug",
     "Enrich": [ "FromLogContext" ],
     "WriteTo": [
+      //{
+      //  "Name": "Slack",
+      //  "Args": {
+      //    "webhookUri": "",
+      //    "restrictedToMinimumLevel": "Warning"
+      //  }
+      //},
       {
         "Name": "RollingFile",
         "Args": { "pathFormat": "logs/gra-{Date}.txt" }


### PR DESCRIPTION
- Fix #203 Add Slack sink for Serilog
- Update CREDITS file to add Newtonsoft.Json, Serilog
- Add startup logging message at level warning with version number