### PR TITLE
Remove question text maximum length requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Changed
+- Remove maximum length from question text
+
 ### Fixed
 - Fix 'assets' directory to deploy properly with default avatars
 - Fix MaxLength errors on user join and registration

--- a/src/GRA.Data/Model/Question.cs
+++ b/src/GRA.Data/Model/Question.cs
@@ -15,7 +15,6 @@ namespace GRA.Data.Model
         public string Name { get; set; }
         public int SortOrder { get; set; }
 
-        [MaxLength(1500)]
         [Required]
         public string Text { get; set; }
         public int CorrectAnswerId { get; set; }

--- a/src/GRA.Domain.Model/Question.cs
+++ b/src/GRA.Domain.Model/Question.cs
@@ -13,7 +13,6 @@ namespace GRA.Domain.Model
         public string Name { get; set; }
         public int SortOrder { get; set; }
 
-        [MaxLength(1500)]
         [Required]
         public string Text { get; set; }
         public int CorrectAnswerId { get; set; }


### PR DESCRIPTION
- 📇 Includes database changes
- Remove question text maximum length requirement