### PR TITLE
Add ability to view community experiences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Changed dynamic avatars
 - Move profile, dashboard, and sign-up to be inside containers to make the site compatible with having a background color/image
 
+### Changed
+- Ability to browse community experiences from the events section
+
 ### Fixed
 - Fix alert spacing
 - Fix signup empty program exception

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Change join branch list to be populated with all branches
 - Change trigger requirement list styling
-- Change recovery token log level to info
 - Ability to browse community experiences from the events section
+- Change events system dropdown to filter events
+- Change recovery token log level to info
 
 ### Fixed
 - Add field to site object to allow forcing https even if the Web server believes the request came in via http.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
-
 ### Added
 - Add disable and spinner to questionnaire submit buttons
 - Add error message when trying to apply a role twice
@@ -21,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Change join branch list to be populated with all branches
 - Change trigger requirement list styling
 - Change recovery token log level to info
+- Ability to browse community experiences from the events section
 
 ### Fixed
 - Add field to site object to allow forcing https even if the Web server believes the request came in via http.
@@ -44,9 +44,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - Changed dynamic avatars
 - Move profile, dashboard, and sign-up to be inside containers to make the site compatible with having a background color/image
-
-### Changed
-- Ability to browse community experiences from the events section
 
 ### Fixed
 - Fix alert spacing

--- a/src/GRA.Controllers/EventsController.cs
+++ b/src/GRA.Controllers/EventsController.cs
@@ -47,12 +47,12 @@ namespace GRA.Controllers
             int? program = null,
             string StartDate = null,
             string EndDate = null,
-            bool communityExperiences = false)
+            bool CommunityExperiences = false)
         {
             EventFilter filter = new EventFilter(page)
             {
                 Search = search,
-                EventType = communityExperiences ? 1 : 0
+                EventType = CommunityExperiences ? 1 : 0
             };
 
             // ignore location if branch has value
@@ -106,7 +106,7 @@ namespace GRA.Controllers
                 SystemList = new SelectList((await _siteService.GetSystemList()), "Id", "Name"),
                 LocationList = new SelectList((await _eventService.GetLocations()), "Id", "Name"),
                 ProgramList = new SelectList((await _siteService.GetProgramList()), "Id", "Name"),
-                CommunityExperiences = communityExperiences
+                CommunityExperiences = CommunityExperiences
             };
             if (branch.HasValue)
             {
@@ -155,7 +155,7 @@ namespace GRA.Controllers
                 endDate = model.EndDate.Value.ToString("MM-dd-yyyy");
             }
 
-            return RedirectToAction("Index", new { Search = model.Search, Branch = model.BranchId, Location = model.LocationId, Program = model.ProgramId, StartDate = startDate, EndDate = endDate });
+            return RedirectToAction("Index", new { Search = model.Search, Branch = model.BranchId, Location = model.LocationId, Program = model.ProgramId, StartDate = startDate, EndDate = endDate, CommunityExperiences = model.CommunityExperiences });
         }
 
         public async Task<IActionResult> Detail(int id)

--- a/src/GRA.Controllers/EventsController.cs
+++ b/src/GRA.Controllers/EventsController.cs
@@ -31,17 +31,19 @@ namespace GRA.Controllers
         }
         public async Task<IActionResult> CommunityExperiences(int page = 1,
             string search = null,
+            int? system = null,
             int? branch = null,
             int? location = null,
             int? program = null,
             string StartDate = null,
             string EndDate = null)
         {
-            return await Index(page, search, branch, location, program, StartDate, EndDate, true);
+            return await Index(page, search, system, branch, location, program, StartDate, EndDate, true);
         }
 
         public async Task<IActionResult> Index(int page = 1,
             string search = null,
+            int? system = null,
             int? branch = null,
             int? location = null,
             int? program = null,
@@ -49,6 +51,7 @@ namespace GRA.Controllers
             string EndDate = null,
             bool CommunityExperiences = false)
         {
+            ModelState.Clear();
             EventFilter filter = new EventFilter(page)
             {
                 Search = search,
@@ -60,6 +63,10 @@ namespace GRA.Controllers
             {
                 filter.BranchIds = new List<int>() { branch.Value };
             }
+            else if(system.HasValue)
+            {
+                filter.SystemIds = new List<int>() { system.Value };
+            }
             else if (location.HasValue)
             {
                 filter.LocationIds = new List<int?>() { location.Value };
@@ -70,10 +77,18 @@ namespace GRA.Controllers
                 filter.ProgramIds = new List<int?>() { program.Value };
             }
 
-            if (!string.IsNullOrWhiteSpace(StartDate))
+            if (!String.Equals(StartDate, "False", StringComparison.OrdinalIgnoreCase))
             {
-                filter.StartDate = DateTime.Parse(StartDate).Date;
+                if (!string.IsNullOrWhiteSpace(StartDate))
+                {
+                    filter.StartDate = DateTime.Parse(StartDate).Date;
+                }
+                else
+                {
+                    filter.StartDate = DateTime.Now.Date;
+                }
             }
+            
             if (!string.IsNullOrWhiteSpace(EndDate))
             {
                 filter.EndDate = DateTime.Parse(EndDate).Date;
@@ -102,12 +117,15 @@ namespace GRA.Controllers
                 Events = eventList.Data,
                 PaginateModel = paginateModel,
                 Search = search,
+                StartDate = filter.StartDate,
+                EndDate = filter.EndDate,
                 ProgramId = program,
                 SystemList = new SelectList((await _siteService.GetSystemList()), "Id", "Name"),
                 LocationList = new SelectList((await _eventService.GetLocations()), "Id", "Name"),
                 ProgramList = new SelectList((await _siteService.GetProgramList()), "Id", "Name"),
                 CommunityExperiences = CommunityExperiences
             };
+
             if (branch.HasValue)
             {
                 var selectedBranch = await _siteService.GetBranchByIdAsync(branch.Value);
@@ -115,6 +133,12 @@ namespace GRA.Controllers
                 viewModel.BranchList = new SelectList(
                     (await _siteService.GetBranches(selectedBranch.SystemId)),
                     "Id", "Name", branch.Value);
+            }
+            else if (system.HasValue)
+            {
+                viewModel.SystemId = system;
+                viewModel.BranchList = new SelectList(
+                    (await _siteService.GetBranches(system.Value)), "Id", "Name");
             }
             else
             {
@@ -133,16 +157,23 @@ namespace GRA.Controllers
         [HttpPost]
         public IActionResult Index(EventsListViewModel model)
         {
-            string startDate = null;
+            string startDate = "False";
             string endDate = null;
+            bool? isCommunityExperience = null;
 
             if (model.UseLocation == true)
             {
+                model.SystemId = null;
                 model.BranchId = null;
             }
             else
             {
                 model.LocationId = null;
+            }
+
+            if (model.BranchId.HasValue)
+            {
+                model.SystemId = null;
             }
 
             if (model.StartDate.HasValue)
@@ -154,8 +185,12 @@ namespace GRA.Controllers
             {
                 endDate = model.EndDate.Value.ToString("MM-dd-yyyy");
             }
+            if (model.CommunityExperiences)
+            {
+                isCommunityExperience = true;
+            }
 
-            return RedirectToAction("Index", new { Search = model.Search, Branch = model.BranchId, Location = model.LocationId, Program = model.ProgramId, StartDate = startDate, EndDate = endDate, CommunityExperiences = model.CommunityExperiences });
+            return RedirectToAction("Index", new { Search = model.Search, System = model.SystemId, Branch = model.BranchId, Location = model.LocationId, Program = model.ProgramId, StartDate = startDate, EndDate = endDate, CommunityExperiences = isCommunityExperience });
         }
 
         public async Task<IActionResult> Detail(int id)

--- a/src/GRA.Controllers/EventsController.cs
+++ b/src/GRA.Controllers/EventsController.cs
@@ -29,8 +29,7 @@ namespace GRA.Controllers
             _siteService = Require.IsNotNull(siteService, nameof(SiteService));
             PageTitle = "Events";
         }
-
-        public async Task<IActionResult> Index(int page = 1,
+        public async Task<IActionResult> CommunityExperiences(int page = 1,
             string search = null,
             int? branch = null,
             int? location = null,
@@ -38,9 +37,22 @@ namespace GRA.Controllers
             string StartDate = null,
             string EndDate = null)
         {
+            return await Index(page, search, branch, location, program, StartDate, EndDate, true);
+        }
+
+        public async Task<IActionResult> Index(int page = 1,
+            string search = null,
+            int? branch = null,
+            int? location = null,
+            int? program = null,
+            string StartDate = null,
+            string EndDate = null,
+            bool communityExperiences = false)
+        {
             EventFilter filter = new EventFilter(page)
             {
                 Search = search,
+                EventType = communityExperiences ? 1 : 0
             };
 
             // ignore location if branch has value
@@ -93,7 +105,8 @@ namespace GRA.Controllers
                 ProgramId = program,
                 SystemList = new SelectList((await _siteService.GetSystemList()), "Id", "Name"),
                 LocationList = new SelectList((await _eventService.GetLocations()), "Id", "Name"),
-                ProgramList = new SelectList((await _siteService.GetProgramList()), "Id", "Name")
+                ProgramList = new SelectList((await _siteService.GetProgramList()), "Id", "Name"),
+                CommunityExperiences = communityExperiences
             };
             if (branch.HasValue)
             {
@@ -114,7 +127,7 @@ namespace GRA.Controllers
                 viewModel.UseLocation = true;
             }
 
-            return View(viewModel);
+            return View("Index", viewModel);
         }
 
         [HttpPost]

--- a/src/GRA.Controllers/ViewModel/Events/EventsListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Events/EventsListViewModel.cs
@@ -29,5 +29,6 @@ namespace GRA.Controllers.ViewModel.Events
         public SelectList BranchList { get; set; }
         public SelectList LocationList { get; set; }
         public SelectList ProgramList { get; set; }
+        public bool CommunityExperiences { get; set; }
     }
 }

--- a/src/GRA.Data/Repository/EventRepository.cs
+++ b/src/GRA.Data/Repository/EventRepository.cs
@@ -169,11 +169,15 @@ namespace GRA.Data.Repository
             // filter by dates
             if (filter.StartDate != null)
             {
-                events = events.Where(_ => _.StartDate.Date >= filter.StartDate.Value.Date);
+                events = events.Where(_ => 
+                ((_.AllDay == false || _.EndDate.HasValue == false) && _.StartDate.Date >= filter.StartDate.Value.Date)
+                || _.EndDate.Value.Date >= filter.StartDate.Value.Date);
             }
             if (filter.EndDate != null)
             {
-                events = events.Where(_ => _.StartDate.Date <= filter.EndDate.Value.Date);
+                events = events.Where(_ => 
+                ((_.AllDay == false || _.EndDate.HasValue == false) && _.StartDate.Date <= filter.EndDate.Value.Date)
+                || _.StartDate.Date <= filter.EndDate.Value.Date);
             }
 
             // apply search

--- a/src/GRA.Web/Views/Events/Detail.cshtml
+++ b/src/GRA.Web/Views/Events/Detail.cshtml
@@ -5,7 +5,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <span class="lead">
-                    Event: @Model.Event.Name
+                    @Model.Event.Name
                 </span>
             </div>
             <div class="panel-body">
@@ -15,7 +15,7 @@
 
                 @if (!string.IsNullOrWhiteSpace(Model.Event.ExternalLink))
                 {
-                    <div class="row-spacing" style="font-size:medium;"><strong>Event Link: </strong><a target="_blank" href="@Model.Event.ExternalLink">@Model.Event.ExternalLink</a></div>
+                    <div class="row-spacing" style="font-size:medium;"><strong>Link: </strong><a target="_blank" href="@Model.Event.ExternalLink">@Model.Event.ExternalLink</a></div>
                 }
                 <div class="row-spacing" style="font-size:medium;">
                     <table>
@@ -56,7 +56,7 @@
             </div>
             <div class="panel-footer clearfix hidden-print">
                 <div class="pull-left">
-                    <return asp-action="Index" class="btn btn-default btn-lg">Return to Events</return>
+                    <return asp-action="Index" class="btn btn-default btn-lg">Return to Events &amp; Community Experiences</return>
                 </div>
             </div>
         </div>

--- a/src/GRA.Web/Views/Events/Detail.cshtml
+++ b/src/GRA.Web/Views/Events/Detail.cshtml
@@ -9,7 +9,17 @@
                 </span>
             </div>
             <div class="panel-body">
-                <div class="row-spacing" style="font-size:medium;"><strong>When: </strong>@Model.Event.StartDate.ToString("d") @(!Model.Event.AllDay ? "at " + Model.Event.StartDate.ToString("t") : "")</div>
+                <div class="row-spacing" style="font-size:medium;">
+                    <strong>When: </strong>
+                    @if (Model.Event.AllDay)
+                    {
+                        @:@Model.Event.StartDate.ToString("d") @(Model.Event.EndDate.HasValue ? "– " + Model.Event.EndDate.Value.ToString("d") : "")
+                    }
+                    else
+                    {
+                        @:@Model.Event.StartDate.ToString("d") at @Model.Event.StartDate.ToString("t")
+                    }
+                </div>
 
                 <div class="row-spacing">@Model.Event.Description</div>
 

--- a/src/GRA.Web/Views/Events/Index.cshtml
+++ b/src/GRA.Web/Views/Events/Index.cshtml
@@ -137,7 +137,14 @@
                                                         @eventItem.Name
                                                     </a>
                                                 </td>
-                                                <td>@eventItem.StartDate.ToString("d") @(!eventItem.AllDay ? "at " + eventItem.StartDate.ToString("t") : "")</td>
+                                                @if (eventItem.AllDay)
+                                                {
+                                                    <td>@eventItem.StartDate.ToString("d") @(eventItem.EndDate.HasValue ? "– " + eventItem.EndDate.Value.ToString("d") : "")</td>
+                                                }
+                                                else
+                                                {
+                                                    <td>@eventItem.StartDate.ToString("d") at @eventItem.StartDate.ToString("t")</td>
+                                                }
                                                 <td>@eventItem.EventLocationName</td>
                                             </tr>
                                         }

--- a/src/GRA.Web/Views/Events/Index.cshtml
+++ b/src/GRA.Web/Views/Events/Index.cshtml
@@ -13,9 +13,18 @@
     <div class="col-xs-12 col-sm-10 col-sm-offset-1">
         <div class="panel panel-default">
             <div class="panel-heading">
-                <span class="lead">Events</span>
+                <span class="lead">Events &amp; Community Experiences</span>
             </div>
             <div class="panel-body">
+                <div class="row row-spacing">
+                    <div class="col-xs-12">
+                        <ul class="nav nav-pills">
+                            <li role="presentation" @if (Model.CommunityExperiences != true) { <text> class="active" </text> }><a asp-action="Index">Events</a></li>
+                            <li role="presentation" @if (Model.CommunityExperiences == true)
+                            {<text>class= "active"</text>}><a asp-action="CommunityExperiences">Community Experiences</a></li>
+                        </ul>
+                    </div>
+                </div>
                 <form asp-controller="Events" asp-action="Index" method="post" role="form">
                     <input asp-for="UseLocation" type="hidden" />
 

--- a/src/GRA.Web/Views/Events/Index.cshtml
+++ b/src/GRA.Web/Views/Events/Index.cshtml
@@ -27,7 +27,9 @@
                 </div>
                 <form asp-controller="Events" asp-action="Index" method="post" role="form">
                     <input asp-for="UseLocation" type="hidden" />
-
+                    <input asp-for="CommunityExperiences" 
+                           type="hidden" 
+                           value="@Model.CommunityExperiences" />
                     <div class="row row-spacing">
                         <div class="col-xs-6">
                             <label asp-for="StartDate" class="control-label"></label>
@@ -91,7 +93,14 @@
                                    placeholder="Enter text to search for an event here" />
                         </div>
                         <div class="col-sm-2 col-xs-6">
-                            <a asp-action="Index" class="btn btn-default btn-block"><span class="hidden-sm fa fa-minus-circle"></span> Clear</a>
+                            @if (Model.CommunityExperiences)
+                            {
+                                <a asp-action="CommunityExperiences" class="btn btn-default btn-block"><span class="hidden-sm fa fa-minus-circle"></span> Clear</a>
+                            }
+                            else
+                            {
+                                <a asp-action="Index" class="btn btn-default btn-block"><span class="hidden-sm fa fa-minus-circle"></span> Clear</a>
+                            }
                         </div>
                         <div class="col-sm-2 col-xs-6">
                             <button type="submit" class="btn btn-primary btn-block"><span class="hidden-sm fa fa-search"></span> Search</button>

--- a/src/GRA.Web/Views/Events/_DetailPartial.cshtml
+++ b/src/GRA.Web/Views/Events/_DetailPartial.cshtml
@@ -5,7 +5,16 @@
     <h4 class="modal-title" id="detailModalLabel">@Model.Event.Name</h4>
 </div>
 <div class="modal-body">
-    <div class="row-spacing" style="font-size:medium;"><strong>When: </strong>@Model.Event.StartDate.ToString("d") @(!Model.Event.AllDay ? "at " + Model.Event.StartDate.ToString("t") : "")</div>
+    <div class="row-spacing" style="font-size:medium;"><strong>When: </strong>
+    @if (Model.Event.AllDay)
+    {
+        @:@Model.Event.StartDate.ToString("d") @(Model.Event.EndDate.HasValue ? "– " + Model.Event.EndDate.Value.ToString("d") : "")
+    }
+    else
+    {
+        @:@Model.Event.StartDate.ToString("d") at @Model.Event.StartDate.ToString("t")
+    }
+    </div>
 
     <div class="row-spacing">@Model.Event.Description</div>
 

--- a/src/GRA.Web/Views/Events/_DetailPartial.cshtml
+++ b/src/GRA.Web/Views/Events/_DetailPartial.cshtml
@@ -2,7 +2,7 @@
 
 <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    <h4 class="modal-title" id="detailModalLabel">Event: @Model.Event.Name</h4>
+    <h4 class="modal-title" id="detailModalLabel">@Model.Event.Name</h4>
 </div>
 <div class="modal-body">
     <div class="row-spacing" style="font-size:medium;"><strong>When: </strong>@Model.Event.StartDate.ToString("d") @(!Model.Event.AllDay ? "at " + Model.Event.StartDate.ToString("t") : "")</div>
@@ -11,7 +11,7 @@
 
     @if (!string.IsNullOrWhiteSpace(Model.Event.ExternalLink))
     {
-        <div class="row-spacing" style="font-size:medium;"><strong>Event Link: </strong><a target="_blank" href="@Model.Event.ExternalLink">@Model.Event.ExternalLink</a></div>
+        <div class="row-spacing" style="font-size:medium;"><strong>Link: </strong><a target="_blank" href="@Model.Event.ExternalLink">@Model.Event.ExternalLink</a></div>
     }
     <div class="row-spacing" style="font-size:medium;">
         <table>


### PR DESCRIPTION
- [x] Add community experiences switch to public event page
- [x] Remove references to event so details work for both events and
  community experiences
- [x] Fix #279 Ensure public users can view events and community experiences
- [x] Proper date filtering (if a community experience or event is running in the date range of the filter (that is: it starts before the start filter date and has no end date or ends after the end filter date) it should be shown)