### PR TITLE
Fix build on OS X and Linux

### DIFF
--- a/src/GRA.Web/GRA.Web.csproj
+++ b/src/GRA.Web/GRA.Web.csproj
@@ -28,10 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="wwwroot\images\no_avatar.png" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Update="wwwroot\**\*;assets\**\*;**\*.cshtml;appsettings.json;web.config">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>


### PR DESCRIPTION
Having the `no_avatar.png` image listed in the `.csproj` `<Content Update="">` seems to have broken the build on OS X and Linux. This modification should fix that.