### PR TITLE
Add SSL override capability; upgrade MailKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- Add field to site object to allow forcing https even if the Web server believes the request came in via http.
 
 ## [4.0.0-alpha5] 2017-05-01
 ### Added

--- a/src/GRA.Controllers/Helpers/SiteTagHelper.cs
+++ b/src/GRA.Controllers/Helpers/SiteTagHelper.cs
@@ -98,6 +98,10 @@ namespace GRA.Controllers.Helpers
         {
             string scheme = ViewContext.HttpContext.Request.Scheme;
             string host = ViewContext.HttpContext.Request.Host.Value;
+            if(site.IsHttpsForced)
+            {
+                scheme = "https";
+            }
             if (site.IsDefault)
             {
                 return $"{scheme}://{host}";

--- a/src/GRA.Data/Model/Site.cs
+++ b/src/GRA.Data/Model/Site.cs
@@ -64,5 +64,6 @@ namespace GRA.Data.Model
         public string TwitterCardImageUrl { get; set; }
         [MaxLength(15)]
         public string TwitterUsername { get; set; }
+        public bool IsHttpsForced { get; set; }
     }
 }

--- a/src/GRA.Domain.Model/Site.cs
+++ b/src/GRA.Domain.Model/Site.cs
@@ -60,5 +60,6 @@ namespace GRA.Domain.Model
         public string TwitterCardImageUrl { get; set; }
         [MaxLength(15)]
         public string TwitterUsername { get; set; }
+        public bool IsHttpsForced { get; set; }
     }
 }

--- a/src/GRA.Domain.Service/GRA.Domain.Service.csproj
+++ b/src/GRA.Domain.Service/GRA.Domain.Service.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="csvhelper" Version="2.16.3" />
-    <PackageReference Include="MailKit" Version="1.14.2" />
+    <PackageReference Include="MailKit" Version="1.16.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.1" />

--- a/src/GRA.Domain.Service/SiteService.cs
+++ b/src/GRA.Domain.Service/SiteService.cs
@@ -97,6 +97,10 @@ namespace GRA.Domain.Service
         public async Task<string> GetBaseUrl(string scheme, string host)
         {
             var site = await _siteRepository.GetByIdAsync(GetCurrentSiteId());
+            if(site.IsHttpsForced)
+            {
+                scheme = "https";
+            }
             if (site.IsDefault)
             {
                 return $"{scheme}://{host}";


### PR DESCRIPTION
- Update MailKit package from 1.14.2 to 1.16.0
- Add force https override for self-published URLs (fix #297)