### PR TITLE
Fix Current Status to use entered points

### DIFF
--- a/src/GRA.Data/Repository/UserLogRepository.cs
+++ b/src/GRA.Data/Repository/UserLogRepository.cs
@@ -402,7 +402,7 @@ namespace GRA.Data.Repository
                     .Where(_ => _.CreatedAt <= request.EndDate);
             }
 
-            return await earnedFilter.SumAsync(_ => Convert.ToInt64(_.PointsEarned));
+            return await earnedFilter.SumAsync(_ => Convert.ToInt64(_.ActivityEarned));
         }
 
     }


### PR DESCRIPTION
Current Status Report was showing translated values as point values rather than entered values prior to translation.