### PR TITLE
Add groups with configurable maximum household size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Allow configuration of donation for received vendor codes
 - Show full link on pages with linkable stubs
 - Mission Control Program management
+- Setting to require households of a certain size to convert to groups and select a configurable group type
 
 ### Changed
 - Add label and border around rich text previews

--- a/src/GRA.Controllers/Base/Controller.cs
+++ b/src/GRA.Controllers/Base/Controller.cs
@@ -250,14 +250,27 @@ namespace GRA.Controllers.Base
         }
 
         /// <summary>
-        /// Look up a site setting by key, if it is set to anything other than NULL return true
+        /// Look up a boolean site setting by key.
         /// </summary>
         /// <param name="key">The site setting key value (a string, up to 255 characters)</param>
         /// <returns>True if the value is set in the database, false if the key is not present or
-        /// set to null.</returns>
+        /// set to NULL.</returns>
         protected async Task<bool> GetSiteSettingBoolAsync(string key)
         {
             return await _siteLookupService.GetSiteSettingBoolAsync(GetCurrentSiteId(), key);
         }
+
+        /// <summary>
+        /// Look up an integer site setting by key.
+        /// </summary>
+        /// <param name="key">The site setting key value (a string, up to 255 characters)</param>
+        /// <returns>A tuple, the bool is true if the setting is present and a number with the
+        /// value being the number. The bool is false if the setting is not set or is not a parsable
+        /// integer.</returns>
+        protected async Task<(bool, int)> GetSiteSettingIntAsync(string key)
+        {
+            return await _siteLookupService.GetSiteSettingIntAsync(GetCurrentSiteId(), key);
+        }
+        
     }
 }

--- a/src/GRA.Controllers/Filter/SiteFilter.cs
+++ b/src/GRA.Controllers/Filter/SiteFilter.cs
@@ -103,6 +103,15 @@ namespace GRA.Controllers.Filter
             httpContext.Items[ItemKey.ShowChallenges] = showChallenges;
             httpContext.Items[ItemKey.ShowEvents] = showEvents;
 
+            if (string.IsNullOrEmpty(httpContext.Session.GetString(SessionKey.CallItGroup)))
+            {
+                httpContext.Items[ItemKey.HouseholdTitle] = "Household";
+            }
+            else
+            {
+                httpContext.Items[ItemKey.HouseholdTitle] = "Group";
+            }
+
             if (!string.IsNullOrWhiteSpace(site.ExternalEventListUrl))
             {
                 httpContext.Items[ItemKey.ExternalEventListUrl] = site.ExternalEventListUrl;

--- a/src/GRA.Controllers/GRA.Controllers.csproj
+++ b/src/GRA.Controllers/GRA.Controllers.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="SmartFormat.NET" Version="2.0.0" />
-    <PackageReference Include="system.valuetuple" Version="4.3.1" />
+    <PackageReference Include="system.valuetuple" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/GRA.Controllers/ItemKey.cs
+++ b/src/GRA.Controllers/ItemKey.cs
@@ -9,6 +9,7 @@ namespace GRA.Controllers
     {
         public const string ExternalEventListUrl = "ExternalEventListUrl";
         public const string GoogleAnalytics = "GoogleAnalytics";
+        public const string HouseholdTitle = "HouseholdTitle";
         public const string NotificationsDisplayed = "NotificationsDisplayed";
         public const string NotificationsList = "NotificationsList";
         public const string NotificationsModal = "NotificationsModal";

--- a/src/GRA.Controllers/MissionControl/CategoriesController.cs
+++ b/src/GRA.Controllers/MissionControl/CategoriesController.cs
@@ -25,7 +25,7 @@ namespace GRA.Controllers.MissionControl
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _categoryService = categoryService ?? throw new
                 ArgumentNullException(nameof(categoryService));
-            PageTitle = "Categories";
+            PageTitle = "Category management";
         }
 
         public async Task<IActionResult> Index(string search, int page = 1)

--- a/src/GRA.Controllers/MissionControl/DashboardController.cs
+++ b/src/GRA.Controllers/MissionControl/DashboardController.cs
@@ -28,7 +28,7 @@ namespace GRA.Controllers.MissionControl
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _dashboardContentService = dashboardContentService
                 ?? throw new ArgumentNullException(nameof(dashboardContentService));
-            PageTitle = "Dashboard Content";
+            PageTitle = "Dashboard Content management";
         }
 
         public async Task<IActionResult> Index(int page = 1, bool archived = false)

--- a/src/GRA.Controllers/MissionControl/GroupTypesController.cs
+++ b/src/GRA.Controllers/MissionControl/GroupTypesController.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using GRA.Controllers.ServiceFacade;
+using GRA.Controllers.ViewModel.MissionControl.GroupTypes;
+using GRA.Controllers.ViewModel.Shared;
+using GRA.Domain.Model;
+using GRA.Domain.Service;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace GRA.Controllers.MissionControl
+{
+    [Area("MissionControl")]
+    [Authorize(Policy = Policy.ManageGroupTypes)]
+
+    public class GroupTypesController : Base.MCController
+    {
+        const int PaginationTake = 15;
+
+        private readonly ILogger<GroupTypesController> _logger;
+        private readonly GroupTypeService _groupTypesService;
+
+        public GroupTypesController(ServiceFacade.Controller context,
+            ILogger<GroupTypesController> logger,
+            GroupTypeService groupTypesService)
+            : base(context)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _groupTypesService = groupTypesService
+                ?? throw new ArgumentNullException(nameof(groupTypesService));
+            PageTitle = "Group Types Management";
+        }
+
+        public async Task<IActionResult> Index(int page = 1)
+        {
+            int skip = PaginationTake * (page - 1);
+            var data = await _groupTypesService.GetAllMCPagedAsync(skip, PaginationTake);
+
+            var paginateModel = new PaginateViewModel
+            {
+                ItemCount = data.Count,
+                CurrentPage = page,
+                ItemsPerPage = PaginationTake
+            };
+
+            if (paginateModel.PastMaxPage)
+            {
+                return RedirectToRoute(
+                    new
+                    {
+                        page = paginateModel.LastPage ?? 1
+                    });
+            }
+
+            return View(new GroupTypesListViewModel
+            {
+                GroupTypes = data.Data,
+                PaginateModel = paginateModel
+            });
+        }
+
+        public async Task<IActionResult> Add(GroupTypesListViewModel viewModel)
+        {
+            if (viewModel.GroupType == null
+               || string.IsNullOrEmpty(viewModel.GroupType.Name)
+               || string.IsNullOrEmpty(viewModel.GroupType.Name.Trim()))
+            {
+                AlertWarning = "Unable to add group type - must supply a name.";
+            }
+            else
+            {
+                var (result, message)
+                    = await _groupTypesService.Add(GetActiveUserId(), viewModel.GroupType.Name);
+                if (result)
+                {
+                    AlertSuccess = $"Successfully added group type <strong>{message}</strong>.";
+                }
+                else
+                {
+                    AlertDanger = $"Could not add group type: {message}";
+                }
+            }
+            return RedirectToAction("Index",
+                new { page = viewModel?.PaginateModel?.CurrentPage ?? 1 });
+        }
+
+        public async Task<IActionResult> Delete(GroupTypesListViewModel viewModel)
+        {
+            if (viewModel.GroupType == null)
+            {
+                AlertWarning = "Unable to remove group type - must supply an id.";
+            }
+            else
+            {
+                string result
+                    = await _groupTypesService.Remove(GetActiveUserId(), viewModel.GroupType.Id);
+                if (string.IsNullOrEmpty(result))
+                {
+                    AlertSuccess = $"Successfully removed group type <strong>{viewModel.GroupType.Name}</strong>.";
+                }
+                else
+                {
+                    AlertDanger = $"Could not remove group type {viewModel.GroupType.Name}: {result}";
+                }
+            }
+
+            return RedirectToAction("Index",
+                new { page = viewModel?.PaginateModel?.CurrentPage ?? 1 });
+        }
+
+        public async Task<IActionResult> Edit(GroupTypesListViewModel viewModel)
+        {
+            if (viewModel.GroupType == null
+               || string.IsNullOrEmpty(viewModel.GroupType.Name)
+               || string.IsNullOrEmpty(viewModel.GroupType.Name.Trim()))
+            {
+                AlertWarning = "Unable to modify group type - must supply a name.";
+            }
+            else
+            {
+                var (result, message) = await _groupTypesService.Edit(GetActiveUserId(),
+                    viewModel.GroupType.Id,
+                    viewModel.GroupType.Name);
+
+                if (result)
+                {
+                    AlertSuccess = $"Successfully modified group type <strong>{message}</strong>.";
+                }
+                else
+                {
+                    AlertDanger = $"Could not modify group type: {message}";
+                }
+            }
+            return RedirectToAction("Index",
+                new { page = viewModel?.PaginateModel?.CurrentPage ?? 1 });
+        }
+
+    }
+}

--- a/src/GRA.Controllers/MissionControl/GroupTypesController.cs
+++ b/src/GRA.Controllers/MissionControl/GroupTypesController.cs
@@ -31,7 +31,7 @@ namespace GRA.Controllers.MissionControl
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _groupTypesService = groupTypesService
                 ?? throw new ArgumentNullException(nameof(groupTypesService));
-            PageTitle = "Group Types Management";
+            PageTitle = "Group Type management";
         }
 
         public async Task<IActionResult> Index(int page = 1)
@@ -55,10 +55,15 @@ namespace GRA.Controllers.MissionControl
                     });
             }
 
+            var (useGroups, maximumHousehold) =
+                await GetSiteSettingIntAsync(SiteSettingKey.Users.MaximumHouseholdSizeBeforeGroup);
+
+
             return View(new GroupTypesListViewModel
             {
                 GroupTypes = data.Data,
-                PaginateModel = paginateModel
+                PaginateModel = paginateModel,
+                MaximumHouseholdMembers = useGroups ? (int?)maximumHousehold : null
             });
         }
 

--- a/src/GRA.Controllers/MissionControl/PagesController.cs
+++ b/src/GRA.Controllers/MissionControl/PagesController.cs
@@ -28,7 +28,7 @@ namespace GRA.Controllers.MissionControl
             _logger = Require.IsNotNull(logger, nameof(logger));
             _pageService = Require.IsNotNull(pageService, nameof(pageService));
             _siteService = siteService ?? throw new ArgumentNullException(nameof(siteService));
-            PageTitle = "Pages";
+            PageTitle = "Page management";
         }
 
         public async Task<IActionResult> Index(int page = 1)

--- a/src/GRA.Controllers/MissionControl/ParticipantsController.cs
+++ b/src/GRA.Controllers/MissionControl/ParticipantsController.cs
@@ -28,6 +28,7 @@ namespace GRA.Controllers.MissionControl
         private readonly ActivityService _activityService;
         private readonly AuthenticationService _authenticationService;
         private readonly DynamicAvatarService _dynamicAvatarService;
+        private readonly GroupTypeService _groupTypeService;
         private readonly MailService _mailService;
         private readonly PointTranslationService _pointTranslationService;
         private readonly PrizeWinnerService _prizeWinnerService;
@@ -42,6 +43,7 @@ namespace GRA.Controllers.MissionControl
             ActivityService activityService,
             AuthenticationService authenticationService,
             DynamicAvatarService dynamicAvatarService,
+            GroupTypeService groupTypeService,
             MailService mailService,
             PointTranslationService pointTranslationService,
             PrizeWinnerService prizeWinnerService,
@@ -60,6 +62,8 @@ namespace GRA.Controllers.MissionControl
                 nameof(authenticationService));
             _dynamicAvatarService = Require.IsNotNull(dynamicAvatarService,
                 nameof(dynamicAvatarService));
+            _groupTypeService = groupTypeService
+                ?? throw new ArgumentNullException(nameof(groupTypeService));
             _mailService = Require.IsNotNull(mailService, nameof(mailService));
             _pointTranslationService = Require.IsNotNull(pointTranslationService,
                 nameof(pointTranslationService));
@@ -410,6 +414,9 @@ namespace GRA.Controllers.MissionControl
 
                 await _vendorCodeService.PopulateVendorCodeStatusAsync(user);
 
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+
                 ParticipantsDetailViewModel viewModel = new ParticipantsDetailViewModel()
                 {
                     User = user,
@@ -417,6 +424,7 @@ namespace GRA.Controllers.MissionControl
                     Username = user.Username,
                     HouseholdCount = await _userService
                         .FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
+                    IsGroup = groupInfo != null,
                     HeadOfHouseholdId = user.HouseholdHeadUserId,
                     HasAccount = !string.IsNullOrWhiteSpace(user.Username),
                     CanEditDetails = UserHasPermission(Permission.EditParticipants),
@@ -590,6 +598,9 @@ namespace GRA.Controllers.MissionControl
             var user = await _userService.GetDetails(id);
             SetPageTitle(user);
 
+            var groupInfo
+                = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+
             LogActivityViewModel viewModel = new LogActivityViewModel()
             {
                 Id = id,
@@ -597,6 +608,7 @@ namespace GRA.Controllers.MissionControl
                     .GetRequiredQuestionnaire(user.Id, user.Age)).HasValue,
                 HouseholdCount = await _userService
                     .FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
+                IsGroup = groupInfo != null,
                 HasAccount = !string.IsNullOrWhiteSpace(user.Username),
                 DisableSecretCode = await GetSiteSettingBoolAsync(SiteSettingKey.SecretCode.Disable),
                 PointTranslation = await _pointTranslationService
@@ -792,6 +804,26 @@ namespace GRA.Controllers.MissionControl
                 if (TempData.ContainsKey(SecretCodeMessage))
                 {
                     viewModel.SecretCodeMessage = (string)TempData[SecretCodeMessage];
+                }
+
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId
+                    ?? user.Id);
+
+                if (groupInfo != null)
+                {
+                    viewModel.GroupName = groupInfo.Name;
+                    viewModel.GroupType = groupInfo.GroupTypeName;
+                    viewModel.IsGroup = true;
+                }
+                else
+                {
+                    var (useGroups, maximumHousehold) =
+                        await GetSiteSettingIntAsync(SiteSettingKey.Users.MaximumHouseholdSizeBeforeGroup);
+                    if (useGroups && household.Count() + 1 >= maximumHousehold)
+                    {
+                        viewModel.UpgradeToGroup = true;
+                    }
                 }
 
                 return View(viewModel);
@@ -1249,6 +1281,9 @@ namespace GRA.Controllers.MissionControl
                 var user = await _userService.GetDetails(id);
                 SetPageTitle(user);
 
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+
                 BookListViewModel viewModel = new BookListViewModel()
                 {
                     Books = books.Data.ToList(),
@@ -1260,6 +1295,7 @@ namespace GRA.Controllers.MissionControl
                         .GetRequiredQuestionnaire(user.Id, user.Age)).HasValue,
                     HouseholdCount = await _userService
                         .FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
+                    IsGroup = groupInfo != null,
                     HeadOfHouseholdId = user.HouseholdHeadUserId,
                     HasAccount = !string.IsNullOrWhiteSpace(user.Username),
                     CanEditBooks = UserHasPermission(Permission.LogActivityForAny),
@@ -1389,6 +1425,9 @@ namespace GRA.Controllers.MissionControl
                 var user = await _userService.GetDetails(id);
                 SetPageTitle(user);
 
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+
                 HistoryListViewModel viewModel = new HistoryListViewModel()
                 {
                     Historys = new List<HistoryItemViewModel>(),
@@ -1396,6 +1435,7 @@ namespace GRA.Controllers.MissionControl
                     Id = id,
                     HouseholdCount = await _userService
                         .FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
+                    IsGroup = groupInfo != null,
                     HeadOfHouseholdId = user.HouseholdHeadUserId,
                     HasAccount = !string.IsNullOrWhiteSpace(user.Username),
                     CanRemoveHistory = UserHasPermission(Permission.LogActivityForAny),
@@ -1533,12 +1573,16 @@ namespace GRA.Controllers.MissionControl
                 var user = await _userService.GetDetails(id);
                 SetPageTitle(user);
 
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+
                 PrizeListViewModel viewModel = new PrizeListViewModel()
                 {
                     PrizeWinners = prizeList.Data,
                     PaginateModel = paginateModel,
                     Id = id,
                     HouseholdCount = await _userService.FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
+                    IsGroup = groupInfo != null,
                     PrizeCount = await _prizeWinnerService.GetUserWinCount(id, false),
                     HeadOfHouseholdId = user.HouseholdHeadUserId,
                     HasAccount = !string.IsNullOrWhiteSpace(user.Username)
@@ -1615,6 +1659,9 @@ namespace GRA.Controllers.MissionControl
                 var user = await _userService.GetDetails(id);
                 SetPageTitle(user);
 
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+                
                 MailListViewModel viewModel = new MailListViewModel()
                 {
                     Mails = mail.Data,
@@ -1622,6 +1669,7 @@ namespace GRA.Controllers.MissionControl
                     Id = id,
                     HouseholdCount = await _userService.FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
                     HeadOfHouseholdId = user.HouseholdHeadUserId,
+                    IsGroup = groupInfo != null,
                     HasAccount = !string.IsNullOrWhiteSpace(user.Username),
                     CanRemoveMail = UserHasPermission(Permission.DeleteAnyMail),
                     CanSendMail = UserHasPermission(Permission.MailParticipants)
@@ -1736,13 +1784,17 @@ namespace GRA.Controllers.MissionControl
                 var user = await _userService.GetDetails(id);
                 SetPageTitle(user);
 
+                var groupInfo
+                    = await _userService.GetGroupFromHouseholdHeadAsync(user.HouseholdHeadUserId ?? id);
+
                 PasswordResetViewModel viewModel = new PasswordResetViewModel()
                 {
                     Id = id,
                     HouseholdCount = await _userService
                         .FamilyMemberCountAsync(user.HouseholdHeadUserId ?? id),
                     HeadOfHouseholdId = user.HouseholdHeadUserId,
-                    HasAccount = !string.IsNullOrWhiteSpace(user.Username)
+                    HasAccount = !string.IsNullOrWhiteSpace(user.Username),
+                    IsGroup = groupInfo != null
                 };
 
                 if (UserHasPermission(Permission.ViewUserPrizes))
@@ -1857,6 +1909,59 @@ namespace GRA.Controllers.MissionControl
                 name += $" ({user.Username})";
             }
             PageTitleHtml = WebUtility.HtmlEncode($"{title} - {name}");
+        }
+
+        [Authorize(Policy = Policy.EditParticipants)]
+        public async Task<IActionResult> UpgradeToGroup(int id)
+        {
+            var (useGroups, maximumHousehold) =
+                await GetSiteSettingIntAsync(SiteSettingKey.Users.MaximumHouseholdSizeBeforeGroup);
+
+            if (!useGroups)
+            {
+                return RedirectToAction("Household", new { id });
+            }
+
+            var groupTypes = await _userService.GetGroupTypeListAsync();
+
+            if (groupTypes.Count() == 0)
+            {
+                _logger.LogError($"MC attempt to add household member, need to make a group, no group types configured.");
+                AlertDanger = "In order to add more members to this household it must be converted to a group, however there are no group types configured.";
+                return View("Household", id);
+            }
+
+            return View("UpgradeToGroup", new GroupUpgradeViewModel
+            {
+                Id = id,
+                MaximumHouseholdAllowed = maximumHousehold,
+                GroupTypes = new SelectList(groupTypes.ToList(), "Id", "Name")
+            });
+        }
+
+        [HttpPost]
+        [Authorize(Policy = Policy.EditParticipants)]
+        public async Task<IActionResult> CreateGroup(GroupUpgradeViewModel viewModel)
+        {
+            if (string.IsNullOrEmpty(viewModel.GroupInfo?.Name?.Trim()))
+            {
+                AlertDanger = "You must specify a group name.";
+                return View("UpgradeToGroup", viewModel);
+            }
+
+            try
+            {
+                viewModel.GroupInfo.UserId = viewModel.Id;
+                await _userService.CreateGroup(GetActiveUserId(), viewModel.GroupInfo);
+            }
+            catch (Exception ex)
+            {
+                AlertDanger = $"Couldn't create group: {ex.Message}";
+                return View("GroupUpgrade", viewModel);
+            }
+
+            AlertSuccess = "Group successfully created, now you may add additional members.";
+            return RedirectToAction("Household", new { id = viewModel.Id });
         }
     }
 }

--- a/src/GRA.Controllers/MissionControl/ProgramsController.cs
+++ b/src/GRA.Controllers/MissionControl/ProgramsController.cs
@@ -38,7 +38,7 @@ namespace GRA.Controllers.MissionControl
             _pointTranslationService = pointTranslationService
                 ?? throw new ArgumentNullException(nameof(pointTranslationService));
             _siteService = siteService ?? throw new ArgumentNullException(nameof(siteService));
-            PageTitle = "Programs";
+            PageTitle = "Program management";
         }
 
         public async Task<IActionResult> Index(string search, int page = 1)

--- a/src/GRA.Controllers/MissionControl/QuestionnairesController.cs
+++ b/src/GRA.Controllers/MissionControl/QuestionnairesController.cs
@@ -28,7 +28,7 @@ namespace GRA.Controllers.MissionControl
             _logger = Require.IsNotNull(logger, nameof(logger));
             _questionnaireService = Require.IsNotNull(questionnaireService,
                 nameof(questionnaireService));
-            PageTitle = "Questionnaires";
+            PageTitle = "Questionnaire management";
         }
 
         public async Task<IActionResult> Index(int page = 1)

--- a/src/GRA.Controllers/MissionControl/SchoolsController.cs
+++ b/src/GRA.Controllers/MissionControl/SchoolsController.cs
@@ -30,7 +30,7 @@ namespace GRA.Controllers.MissionControl
             _schoolImportService = Require.IsNotNull(schoolImportService,
                 nameof(schoolImportService));
             _schoolService = Require.IsNotNull(schoolService, nameof(schoolService));
-            PageTitle = "Schools";
+            PageTitle = "School management";
         }
 
         public async Task<IActionResult> Index(string search, int page = 1)

--- a/src/GRA.Controllers/MissionControl/SystemsController.cs
+++ b/src/GRA.Controllers/MissionControl/SystemsController.cs
@@ -25,7 +25,7 @@ namespace GRA.Controllers.MissionControl
         {
             _logger = Require.IsNotNull(logger, nameof(logger));
             _siteService = Require.IsNotNull(siteService, nameof(siteService));
-            PageTitle = "System";
+            PageTitle = "System & branch management";
         }
 
         public async Task<IActionResult> Index(string search, int page = 1)

--- a/src/GRA.Controllers/MissionControl/VendorCodesController.cs
+++ b/src/GRA.Controllers/MissionControl/VendorCodesController.cs
@@ -28,7 +28,7 @@ namespace GRA.Controllers.MissionControl
             _siteService = siteService ?? throw new ArgumentNullException(nameof(siteService));
             _vendorCodeService = vendorCodeService
                 ?? throw new ArgumentNullException(nameof(vendorCodeService));
-            PageTitle = "Vendor Codes";
+            PageTitle = "Vendor code management";
         }
 
         [HttpGet]

--- a/src/GRA.Controllers/ProfileController.cs
+++ b/src/GRA.Controllers/ProfileController.cs
@@ -11,6 +11,7 @@ using GRA.Domain.Service;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
 
@@ -35,6 +36,8 @@ namespace GRA.Controllers
         private readonly SiteService _siteService;
         private readonly UserService _userService;
         private readonly VendorCodeService _vendorCodeService;
+
+        private string HouseholdTitle;
 
         public ProfileController(ILogger<ProfileController> logger,
             ServiceFacade.Controller context,
@@ -70,6 +73,12 @@ namespace GRA.Controllers
             _userService = Require.IsNotNull(userService, nameof(userService));
             _vendorCodeService = Require.IsNotNull(vendorCodeService, nameof(vendorCodeService));
             PageTitle = "My Profile";
+        }
+
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            base.OnActionExecuting(context);
+            HouseholdTitle = HttpContext.Items[ItemKey.HouseholdTitle] as string ?? "Household";
         }
 
         public async Task<IActionResult> Index()
@@ -256,12 +265,17 @@ namespace GRA.Controllers
             User headUser = null;
             bool authUserIsHead = !authUser.HouseholdHeadUserId.HasValue;
             bool showVendorCodes = authUserIsHead && await _vendorCodeService.SiteHasCodesAsync();
+            GroupInfo groupInfo = null;
+
             if (!authUserIsHead)
             {
+                groupInfo = await _userService.GetGroupFromHouseholdHeadAsync(headUser?.Id
+                    ?? (int)authUser.HouseholdHeadUserId);
                 headUser = await _userService.GetDetails((int)authUser.HouseholdHeadUserId);
             }
             else
             {
+                groupInfo = await _userService.GetGroupFromHouseholdHeadAsync(authUser.Id);
                 authUser.HasNewMail = await _mailService.UserHasUnreadAsync(authUser.Id);
                 if (showVendorCodes)
                 {
@@ -290,6 +304,12 @@ namespace GRA.Controllers
                 PointTranslation = await _pointTranslationService
                         .GetByProgramIdAsync(authUser.ProgramId, true)
             };
+
+            if (groupInfo != null)
+            {
+                viewModel.GroupName = groupInfo.Name;
+                viewModel.GroupLeader = authUserIsHead && authUser.Id == activeUserId;
+            }
 
             if (authUserIsHead)
             {
@@ -386,7 +406,7 @@ namespace GRA.Controllers
             }
             else
             {
-                TempData[ActivityMessage] = "No household members selected.";
+                TempData[ActivityMessage] = "No members selected.";
             }
 
             return RedirectToAction("Household");
@@ -427,7 +447,7 @@ namespace GRA.Controllers
             }
             else
             {
-                TempData[SecretCodeMessage] = "No household members selected.";
+                TempData[SecretCodeMessage] = "No members selected.";
             }
 
             return RedirectToAction("Household");
@@ -438,7 +458,41 @@ namespace GRA.Controllers
             var authUser = await _userService.GetDetails(GetId(ClaimType.UserId));
             if (authUser.HouseholdHeadUserId != null)
             {
+                // if the authUser has a household head then they are not the household head
                 return RedirectToAction("Household");
+            }
+
+            var (useGroups, maximumHousehold) =
+                await GetSiteSettingIntAsync(SiteSettingKey.Users.MaximumHouseholdSizeBeforeGroup);
+
+            if (useGroups)
+            {
+                var groupTypes = await _userService.GetGroupTypeListAsync();
+
+                if (groupTypes.Count() == 0)
+                {
+                    _logger.LogError($"User {authUser.Id} should be forced to make a group but no group types are configured");
+                }
+                else
+                {
+                    var household
+                        = await _userService.GetHouseholdAsync(authUser.Id, false, false, false);
+                    if (household.Count() > maximumHousehold)
+                    {
+                        var groupInfo
+                            = await _userService.GetGroupFromHouseholdHeadAsync(authUser.Id);
+
+                        if (groupInfo == null)
+                        {
+                            _logger.LogInformation($"Redirecting user {authUser.Id} to create a group when adding member {maximumHousehold + 1}");
+                            return View("GroupUpgrade", new GroupUpgradeViewModel
+                            {
+                                MaximumHouseholdAllowed = maximumHousehold,
+                                GroupTypes = new SelectList(groupTypes.ToList(), "Id", "Name")
+                            });
+                        }
+                    }
+                }
             }
 
             var userBase = new User()
@@ -560,7 +614,7 @@ namespace GRA.Controllers
                 }
                 catch (GraException gex)
                 {
-                    ShowAlertDanger("Unable to add household member: ", gex);
+                    ShowAlertDanger("Unable to add member: ", gex);
                 }
             }
             var branchList = await _siteService.GetBranches(model.User.SystemId);
@@ -631,18 +685,102 @@ namespace GRA.Controllers
             {
                 try
                 {
+                    // check if we're going to trip group membership requirements
+                    var (useGroups, maximumHousehold) =
+                        await GetSiteSettingIntAsync(SiteSettingKey.Users.MaximumHouseholdSizeBeforeGroup);
+
+                    int? addUserId = null;
+
+                    if (useGroups)
+                    {
+                        var groupTypes = await _userService.GetGroupTypeListAsync();
+
+                        if (groupTypes.Count() == 0)
+                        {
+                            _logger.LogError($"User {authUser.Id} should be forced to make a group but no group types are configured");
+                        }
+                        else
+                        {
+                            var currentHousehold = await _userService.GetHouseholdAsync(authUser.Id,
+                                false,
+                                false,
+                                false);
+
+                            int totalAddCount = 0;
+                            (totalAddCount, addUserId)
+                                = await _userService.CountParticipantsToAdd(model.Username,
+                                model.Password);
+
+                            if (currentHousehold.Count() + totalAddCount > maximumHousehold)
+                            {
+                                var groupInfo
+                                    = await _userService.GetGroupFromHouseholdHeadAsync(authUser.Id);
+
+                                if (groupInfo == null)
+                                {
+                                    _logger.LogInformation($"Redirecting user {authUser.Id} to create a group when adding member {maximumHousehold + 1}, group will total {currentHousehold.Count() + totalAddCount}");
+                                    // add authenticated user id to session
+                                    if (addUserId != null)
+                                    {
+                                        HttpContext.Session
+                                            .SetString(SessionKey.AbsorbUserId, addUserId.ToString());
+                                    }
+                                    return View("GroupUpgrade", new GroupUpgradeViewModel
+                                    {
+                                        MaximumHouseholdAllowed = maximumHousehold,
+                                        GroupTypes = new SelectList(groupTypes.ToList(), "Id", "Name"),
+                                        AddExisting = true
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    // end checking about groups
+
                     string addedMembers = await _userService
                         .AddParticipantToHouseholdAsync(model.Username, model.Password);
                     HttpContext.Session.SetString(SessionKey.HeadOfHousehold, "True");
-                    ShowAlertSuccess(addedMembers + " has been added to your household");
+                    ShowAlertSuccess($"{addedMembers} has been added to your {HouseholdTitle.ToLower()}");
                     return RedirectToAction("Household");
                 }
                 catch (GraException gex)
                 {
-                    ShowAlertDanger("Could not add participant to household: ", gex.Message);
+                    HttpContext.Session.Remove(SessionKey.AbsorbUserId);
+                    ShowAlertDanger($"Could not add participant as {HouseholdTitle.ToLower()} Member: ", gex);
                 }
             }
             return View(model);
+        }
+
+        [HttpPost]
+        private async Task<IActionResult> AddExistingPreAuth()
+        {
+            var authUser = await _userService.GetDetails(GetId(ClaimType.UserId));
+            if (authUser.HouseholdHeadUserId != null)
+            {
+                return RedirectToAction("Household");
+            }
+
+            if (!int.TryParse(HttpContext.Session.GetString(SessionKey.AbsorbUserId),
+                out int userId))
+            {
+                return RedirectToAction("Household");
+            }
+
+            try
+            {
+                string addedMembers = await _userService
+                    .AddParticipantToHouseholdAlreadyAuthorizedAsync(userId);
+                HttpContext.Session.SetString(SessionKey.HeadOfHousehold, "True");
+                HttpContext.Session.Remove(SessionKey.AbsorbUserId);
+                ShowAlertSuccess($"{addedMembers} has been added to your {HouseholdTitle.ToLower()}");
+            }
+            catch (GraException gex)
+            {
+                HttpContext.Session.Remove(SessionKey.AbsorbUserId);
+                ShowAlertDanger($"Could not add participant as {HouseholdTitle.ToLower()} Member: ", gex);
+            }
+            return RedirectToAction("Household");
         }
 
         public IActionResult RegisterHouseholdMember()
@@ -668,12 +806,12 @@ namespace GRA.Controllers
                     try
                     {
                         await _userService.RegisterHouseholdMemberAsync(user, model.Password);
-                        AlertSuccess = "Household member registered!";
+                        AlertSuccess = $"{HouseholdTitle} member registered!";
                         return RedirectToAction("Household");
                     }
                     catch (GraException gex)
                     {
-                        ShowAlertDanger("Unable to register household member: ", gex);
+                        ShowAlertDanger($"Unable to register {HouseholdTitle.ToLower()} member: ", gex);
                     }
                 }
                 return View("HouseholdRegisterMember", model);
@@ -981,6 +1119,66 @@ namespace GRA.Controllers
             int userId = int.Parse(redeemButton);
             await _vendorCodeService.ResolveDonationStatusAsync(userId, false);
             return RedirectToAction("Household", "Profile");
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateGroup(GroupUpgradeViewModel viewModel)
+        {
+            if (string.IsNullOrEmpty(viewModel.GroupInfo?.Name?.Trim()))
+            {
+                AlertDanger = "You must specify a group name.";
+                return View("GroupUpgrade", viewModel);
+            }
+
+            try
+            {
+                viewModel.GroupInfo.UserId = GetActiveUserId();
+                await _userService.CreateGroup(viewModel.GroupInfo.UserId, viewModel.GroupInfo);
+            }
+            catch (Exception ex)
+            {
+                AlertDanger = $"Couldn't create group: {ex.Message}";
+                return View("GroupUpgrade", viewModel);
+            }
+            HttpContext.Session.SetString(SessionKey.CallItGroup, "True");
+
+            if (viewModel.AddExisting == true)
+            {
+                return await AddExistingPreAuth();
+            }
+            else
+            {
+                return await AddHouseholdMember();
+            }
+        }
+
+        public async Task<IActionResult> GroupDetails()
+        {
+            var authUser = await _userService.GetDetails(GetId(ClaimType.UserId));
+            var groupInfo = await _userService.GetGroupFromHouseholdHeadAsync(authUser.Id);
+
+            if (groupInfo == null)
+            {
+                return RedirectToAction("Household");
+            }
+            else
+            {
+                return View("GroupDetails", new GroupInfo
+                {
+                    Id = groupInfo.Id,
+                    Name = groupInfo.Name,
+                    GroupTypeName = groupInfo.GroupTypeName
+                });
+            }
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> GroupDetails(GroupInfo groupInfo)
+        {
+            var authUser = await _userService.GetDetails(GetId(ClaimType.UserId));
+            groupInfo.UserId = authUser.Id;
+            await _userService.UpdateGroupName(authUser.Id, groupInfo);
+            return RedirectToAction("Household");
         }
     }
 }

--- a/src/GRA.Controllers/ProfileController.cs
+++ b/src/GRA.Controllers/ProfileController.cs
@@ -789,6 +789,16 @@ namespace GRA.Controllers
         }
 
         [HttpPost]
+        public IActionResult CancelGroupUpgrade(GroupUpgradeViewModel viewModel)
+        {
+            if(viewModel.AddExisting == true)
+            {
+                HttpContext.Session.Remove(SessionKey.AbsorbUserId);
+            }
+            return RedirectToAction("Household");
+        }
+
+        [HttpPost]
         public async Task<IActionResult> RegisterHouseholdMember(HouseholdRegisterViewModel model)
         {
             var user = await _userService.GetDetails(model.RegisterId);

--- a/src/GRA.Controllers/SessionKey.cs
+++ b/src/GRA.Controllers/SessionKey.cs
@@ -4,7 +4,9 @@ namespace GRA.Controllers
     public static class SessionKey
     {
         public const string SiteId = "SiteId";
+        public const string AbsorbUserId = "AbsorbUserId";
         public const string ActiveUserId = "ActiveUserId";
+        public const string CallItGroup = "CallItGroup";
         public const string ChallengeSearch = "ChallengeSearch";
         public const string ChallengePage = "ChallengePage";
         public const string PendingQuestionnaire = "PendingQuestionnaire";

--- a/src/GRA.Controllers/SignInController.cs
+++ b/src/GRA.Controllers/SignInController.cs
@@ -64,6 +64,17 @@ namespace GRA.Controllers
                         {
                             HttpContext.Session.SetString(SessionKey.HeadOfHousehold, "True");
                         }
+
+                        int householdHeadId = loginAttempt.User.HouseholdHeadUserId 
+                            ?? loginAttempt.User.Id;
+
+                        var group 
+                            = await _userService.GetGroupFromHouseholdHeadAsync(householdHeadId);
+                        if (group != null)
+                        {
+                            HttpContext.Session.SetString(SessionKey.CallItGroup, "True");
+                        }
+
                         var questionnaireId = await _questionnaireService
                             .GetRequiredQuestionnaire(loginAttempt.User.Id, loginAttempt.User.Age);
                         if (questionnaireId.HasValue)

--- a/src/GRA.Controllers/ViewModel/MissionControl/GroupTypes/GroupTypesListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/GroupTypes/GroupTypesListViewModel.cs
@@ -11,5 +11,6 @@ namespace GRA.Controllers.ViewModel.MissionControl.GroupTypes
         public IEnumerable<GroupType> GroupTypes { get; set; }
         public PaginateViewModel PaginateModel { get; set; }
         public GroupType GroupType { get; set; }
+        public int? MaximumHouseholdMembers { get; set; }
     }
 }

--- a/src/GRA.Controllers/ViewModel/MissionControl/GroupTypes/GroupTypesListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/GroupTypes/GroupTypesListViewModel.cs
@@ -1,0 +1,15 @@
+﻿using GRA.Controllers.ViewModel.Shared;
+using GRA.Domain.Model;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Controllers.ViewModel.MissionControl.GroupTypes
+{
+    public class GroupTypesListViewModel
+    {
+        public IEnumerable<GroupType> GroupTypes { get; set; }
+        public PaginateViewModel PaginateModel { get; set; }
+        public GroupType GroupType { get; set; }
+    }
+}

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/BookListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/BookListViewModel.cs
@@ -3,19 +3,15 @@ using GRA.Controllers.ViewModel.Shared;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class BookListViewModel
+    public class BookListViewModel : ParticipantPartialViewModel
     {
         public List<GRA.Domain.Model.Book> Books { get; set; }
         public PaginateViewModel PaginateModel { get; set; }
         public string Sort { get; set; }
         public bool IsDescending { get; set; }
         public GRA.Domain.Model.Book Book { get; set; }
-        public int Id { get; set; }
         public bool HasPendingQuestionnaire { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
         public bool CanEditBooks { get; set; }
         public System.Array SortBooks { get; set; }
     }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/GroupUpgradeViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/GroupUpgradeViewModel.cs
@@ -1,0 +1,13 @@
+﻿using GRA.Domain.Model;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace GRA.Controllers.ViewModel.MissionControl.Participants
+{
+    public class GroupUpgradeViewModel
+    {
+        public int Id { get; set; }
+        public int MaximumHouseholdAllowed { get; set; }
+        public GroupInfo GroupInfo { get; set; }
+        public SelectList GroupTypes { get; set; }
+    }
+}

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/HistoryListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/HistoryListViewModel.cs
@@ -3,15 +3,11 @@ using System.Collections.Generic;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class HistoryListViewModel
+    public class HistoryListViewModel : ParticipantPartialViewModel
     {
         public List<HistoryItemViewModel> Historys { get; set; }
         public PaginateViewModel PaginateModel { get; set; }
-        public int Id { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
         public bool CanRemoveHistory { get; set; }
         public int TotalPoints { get; set; }
     }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/HouseholdListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/HouseholdListViewModel.cs
@@ -3,14 +3,10 @@ using GRA.Domain.Model;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class HouseholdListViewModel
+    public class HouseholdListViewModel : ParticipantPartialViewModel
     {
         public IEnumerable<GRA.Domain.Model.User> Users { get; set; }
-        public int Id { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
         public bool CanEditDetails { get; set; }
         public bool CanLogActivity { get; set; }
         public bool CanReadMail { get; set; }
@@ -29,5 +25,8 @@ namespace GRA.Controllers.ViewModel.MissionControl.Participants
 
         public IEnumerable<GRA.Domain.Model.Branch> BranchList { get; set; }
         public IEnumerable<GRA.Domain.Model.System> SystemList { get; set; }
+        public bool UpgradeToGroup { get; set; }
+        public string GroupName { get; set; }
+        public string GroupType { get; set; }
     }
 }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/LogActivityViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/LogActivityViewModel.cs
@@ -4,13 +4,9 @@ using GRA.Domain.Model;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class LogActivityViewModel
+    public class LogActivityViewModel : ParticipantPartialViewModel
     {
-        public int Id { get; set; }
         public bool HasPendingQuestionnaire { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
-        public bool HasAccount { get; set; }
         [DisplayName("Activity Amount")]
         public int? ActivityAmount { get; set; }
         public bool DisableSecretCode { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/MailListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/MailListViewModel.cs
@@ -3,15 +3,11 @@ using System.Collections.Generic;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class MailListViewModel
+    public class MailListViewModel : ParticipantPartialViewModel
     {
         public IEnumerable<GRA.Domain.Model.Mail> Mails { get; set; }
         public PaginateViewModel PaginateModel { get; set; }
-        public int Id { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
         public bool CanRemoveMail { get; set; }
         public bool CanSendMail { get; set; }
     }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/ParticipantPartialViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/ParticipantPartialViewModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GRA.Controllers.ViewModel.MissionControl.Participants
+{
+    public abstract class ParticipantPartialViewModel
+    {
+        public int Id { get; set; }
+        public int HouseholdCount { get; set; }
+        public int PrizeCount { get; set; }
+        public bool HasAccount { get; set; }
+        public bool IsGroup { get; set; }
+    }
+}

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/ParticipantsDetailViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/ParticipantsDetailViewModel.cs
@@ -2,15 +2,11 @@
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class ParticipantsDetailViewModel
+    public class ParticipantsDetailViewModel : ParticipantPartialViewModel
     {
         public GRA.Domain.Model.User User { get; set; }
-        public int Id { get; set; }
         public string Username { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
         public bool CanEditDetails { get; set; }
         public bool CanEditUsername { get; set; }
         public bool RequirePostalCode { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/PasswordResetViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/PasswordResetViewModel.cs
@@ -7,13 +7,9 @@ using System.Threading.Tasks;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class PasswordResetViewModel
+    public class PasswordResetViewModel : ParticipantPartialViewModel
     {
-        public int Id { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
         [Required]
         [DisplayName("New Password")]
         public string NewPassword { get; set; }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/PrizeListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/PrizeListViewModel.cs
@@ -6,14 +6,10 @@ using System.Threading.Tasks;
 
 namespace GRA.Controllers.ViewModel.MissionControl.Participants
 {
-    public class PrizeListViewModel
+    public class PrizeListViewModel : ParticipantPartialViewModel
     {
         public IEnumerable<GRA.Domain.Model.PrizeWinner> PrizeWinners { get; set; }
         public PaginateViewModel PaginateModel { get; set; }
-        public int Id { get; set; }
-        public int HouseholdCount { get; set; }
-        public int PrizeCount { get; set; }
         public int? HeadOfHouseholdId { get; set; }
-        public bool HasAccount { get; set; }
     }
 }

--- a/src/GRA.Controllers/ViewModel/MissionControl/Participants/UpdateGroupViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/MissionControl/Participants/UpdateGroupViewModel.cs
@@ -1,0 +1,12 @@
+﻿using GRA.Domain.Model;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace GRA.Controllers.ViewModel.MissionControl.Participants
+{
+    public class UpdateGroupViewModel
+    {
+        public int HouseholdHeadUserId { get; set; }
+        public GroupInfo GroupInfo { get; set; }
+        public SelectList GroupTypes { get; set; }
+    }
+}

--- a/src/GRA.Controllers/ViewModel/Profile/GroupUpgradeViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Profile/GroupUpgradeViewModel.cs
@@ -1,0 +1,13 @@
+﻿using GRA.Domain.Model;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace GRA.Controllers.ViewModel.Profile
+{
+    public class GroupUpgradeViewModel
+    {
+        public int MaximumHouseholdAllowed { get; set; }
+        public GroupInfo GroupInfo { get; set; }
+        public SelectList GroupTypes { get; set; }
+        public bool AddExisting { get; set; }
+    }
+}

--- a/src/GRA.Controllers/ViewModel/Profile/HouseholdListViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Profile/HouseholdListViewModel.cs
@@ -24,5 +24,7 @@ namespace GRA.Controllers.ViewModel.Profile
         public PointTranslation PointTranslation { get; set; }
 
         public Dictionary<int, DailyImageViewModel> DailyImageDictionary { get; set; }
+        public string GroupName { get; set; }
+        public bool GroupLeader { get; set; }
     }
 }

--- a/src/GRA.Controllers/ViewModel/Shared/PaginateViewModel.cs
+++ b/src/GRA.Controllers/ViewModel/Shared/PaginateViewModel.cs
@@ -72,5 +72,13 @@ namespace GRA.Controllers.ViewModel.Shared
                 return last;
             }
         }
+
+        public bool PastMaxPage
+        {
+            get
+            {
+                return MaxPage > 0 && CurrentPage > MaxPage;
+            }
+        }
     }
 }

--- a/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
+++ b/src/GRA.Data.SqlServer/GRA.Data.SqlServer.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Migrations\20180111222409_initial.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\GRA\GRA.csproj" />
     <ProjectReference Include="..\GRA.Data\GRA.Data.csproj" />
   </ItemGroup>

--- a/src/GRA.Data/Context.cs
+++ b/src/GRA.Data/Context.cs
@@ -152,6 +152,8 @@ namespace GRA.Data
         public DbSet<Model.EmailReminder> EmailReminders { get; set; }
         public DbSet<Model.EnteredSchool> EnteredSchools { get; set; }
         public DbSet<Model.Event> Events { get; set; }
+        public DbSet<Model.GroupInfo> GroupInfos { get; set; }
+        public DbSet<Model.GroupType> GroupTypes { get; set; }
         public DbSet<Model.Location> Locations { get; set; }
         public DbSet<Model.Mail> Mails { get; set; }
         public DbSet<Model.Notification> Notifications { get; set; }

--- a/src/GRA.Data/Model/GroupInfo.cs
+++ b/src/GRA.Data/Model/GroupInfo.cs
@@ -5,8 +5,6 @@ namespace GRA.Data.Model
     public class GroupInfo : Abstract.BaseDbEntity
     {
         [Required]
-        public int SiteId { get; set; }
-        [Required]
         public int UserId { get; set; }
         public User User { get; set; }
         [Required]

--- a/src/GRA.Data/Model/GroupInfo.cs
+++ b/src/GRA.Data/Model/GroupInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Data.Model
+{
+    public class GroupInfo : Abstract.BaseDbEntity
+    {
+        [Required]
+        public int SiteId { get; set; }
+        [Required]
+        public int UserId { get; set; }
+        public User User { get; set; }
+        [Required]
+        [MaxLength(255)]
+        public string Name { get; set; }
+        [Required]
+        public int GroupTypeId { get; set; }
+        public GroupType GroupType { get; set; }
+    }
+}

--- a/src/GRA.Data/Model/GroupType.cs
+++ b/src/GRA.Data/Model/GroupType.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Data.Model
+{
+    public class GroupType : Abstract.BaseDbEntity
+    {
+        [Required]
+        public int SiteId { get; set; }
+        [Required]
+        [MaxLength(255)]
+        public string Name { get; set; }
+    }
+}

--- a/src/GRA.Data/Profile/MappingProfile.cs
+++ b/src/GRA.Data/Profile/MappingProfile.cs
@@ -59,6 +59,8 @@ namespace GRA.Data.Profile
                 .ForMember(dest => dest.Challenge, opt => opt.Ignore())
                 .ForMember(dest => dest.ChallengeGroup, opt => opt.Ignore())
                 .ReverseMap();
+            CreateMap<Model.GroupInfo, Domain.Model.GroupInfo>().ReverseMap();
+            CreateMap<Model.GroupType, Domain.Model.GroupType>().ReverseMap();
             CreateMap<Model.Location, Domain.Model.Location>().ReverseMap();
             CreateMap<Model.Mail, Domain.Model.Mail>().ReverseMap();
             CreateMap<Model.Notification, Domain.Model.Notification>().ReverseMap();

--- a/src/GRA.Data/Repository/GroupInfoRepository.cs
+++ b/src/GRA.Data/Repository/GroupInfoRepository.cs
@@ -1,0 +1,25 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using GRA.Domain.Repository;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace GRA.Data.Repository
+{
+    public class GroupInfoRepository : AuditingRepository<Model.GroupInfo, Domain.Model.GroupInfo>,
+        IGroupInfoRepository
+    {
+        public GroupInfoRepository(ServiceFacade.Repository repositoryFacade,
+            ILogger<GroupInfoRepository> logger) : base(repositoryFacade, logger)
+        {
+        }
+
+        public async Task<int> GetCountByTypeAsync(int groupTypeId)
+        {
+            return await DbSet
+                .AsNoTracking()
+                .Where(_ => _.GroupTypeId == groupTypeId)
+                .CountAsync();
+        }
+    }
+}

--- a/src/GRA.Data/Repository/GroupInfoRepository.cs
+++ b/src/GRA.Data/Repository/GroupInfoRepository.cs
@@ -1,5 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using AutoMapper.QueryableExtensions;
+using GRA.Domain.Model;
 using GRA.Domain.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -12,6 +14,16 @@ namespace GRA.Data.Repository
         public GroupInfoRepository(ServiceFacade.Repository repositoryFacade,
             ILogger<GroupInfoRepository> logger) : base(repositoryFacade, logger)
         {
+        }
+
+        public async Task<GroupInfo> GetByUserIdAsync(int householdHeadUserId)
+        {
+            return await DbSet
+                .AsNoTracking()
+                .Where(_ => _.UserId == householdHeadUserId)
+                .Include(_ => _.GroupType)
+                .ProjectTo<GroupInfo>()
+                .SingleOrDefaultAsync();
         }
 
         public async Task<int> GetCountByTypeAsync(int groupTypeId)

--- a/src/GRA.Data/Repository/GroupTypeRepository.cs
+++ b/src/GRA.Data/Repository/GroupTypeRepository.cs
@@ -17,6 +17,20 @@ namespace GRA.Data.Repository
         {
         }
 
+        public async Task<IEnumerable<GroupType>> GetAllForListAsync(int siteId)
+        {
+            return await DbSet
+                .AsNoTracking()
+                .Where(_ => _.SiteId == siteId)
+                .OrderBy(_ => _.Name)
+                .Select(_ => new GroupType
+                {
+                    Id = _.Id,
+                    Name = _.Name
+                })
+                .ToListAsync();
+        }
+
         public async Task<(IEnumerable<GroupType>, int)> GetAllPagedAsync(int siteId,
             int skip,
             int take)

--- a/src/GRA.Data/Repository/GroupTypeRepository.cs
+++ b/src/GRA.Data/Repository/GroupTypeRepository.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper.QueryableExtensions;
+using GRA.Domain.Model;
+using GRA.Domain.Repository;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace GRA.Data.Repository
+{
+    public class GroupTypeRepository : AuditingRepository<Model.GroupType, Domain.Model.GroupType>,
+        IGroupTypeRepository
+    {
+        public GroupTypeRepository(ServiceFacade.Repository repositoryFacade,
+            ILogger<GroupTypeRepository> logger) : base(repositoryFacade, logger)
+        {
+        }
+
+        public async Task<(IEnumerable<GroupType>, int)> GetAllPagedAsync(int siteId,
+            int skip,
+            int take)
+        {
+            var count = await DbSet.CountAsync();
+            var list = await DbSet
+                .AsNoTracking()
+                .Where(_ => _.SiteId == siteId)
+                .OrderBy(_ => _.Name)
+                .Skip(skip)
+                .Take(take)
+                .ProjectTo<GroupType>()
+                .ToListAsync();
+            return (list, count);
+        }
+    }
+}

--- a/src/GRA.Domain.Model/GroupInfo.cs
+++ b/src/GRA.Domain.Model/GroupInfo.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Domain.Model
+{
+    public class GroupInfo : Abstract.BaseDomainEntity
+    {
+        public int SiteId { get; set; }
+        [Required]
+        public int UserId { get; set; }
+        public User User { get; set; }
+        [Required]
+        [MaxLength(255)]
+        [DisplayName("Group name")]
+        public string Name { get; set; }
+        [Required]
+        public int GroupTypeId { get; set; }
+        public GroupType GroupType { get; set; }
+        public string GroupTypeName { get; set; }
+    }
+}

--- a/src/GRA.Domain.Model/GroupInfo.cs
+++ b/src/GRA.Domain.Model/GroupInfo.cs
@@ -5,7 +5,6 @@ namespace GRA.Domain.Model
 {
     public class GroupInfo : Abstract.BaseDomainEntity
     {
-        public int SiteId { get; set; }
         [Required]
         public int UserId { get; set; }
         public User User { get; set; }
@@ -14,8 +13,10 @@ namespace GRA.Domain.Model
         [DisplayName("Group name")]
         public string Name { get; set; }
         [Required]
+        [DisplayName("Group type")]
         public int GroupTypeId { get; set; }
         public GroupType GroupType { get; set; }
+        [DisplayName("Group type")]
         public string GroupTypeName { get; set; }
     }
 }

--- a/src/GRA.Domain.Model/GroupType.cs
+++ b/src/GRA.Domain.Model/GroupType.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace GRA.Domain.Model
+{
+    public class GroupType : Abstract.BaseDomainEntity
+    {
+        public int SiteId { get; set; }
+        [Required]
+        [MaxLength(255)]
+        [DisplayName("Group type")]
+        public string Name { get; set; }
+    }
+}

--- a/src/GRA.Domain.Model/Permission.cs
+++ b/src/GRA.Domain.Model/Permission.cs
@@ -25,6 +25,7 @@ namespace GRA.Domain.Model
         ManageDailyLiteracyTips,
         ManageDashboardContent,
         ManageEvents,
+        ManageGroupTypes,
         ManageLocations,
         ManagePointTranslations,
         ManagePrograms,

--- a/src/GRA.Domain.Model/Policy.cs
+++ b/src/GRA.Domain.Model/Policy.cs
@@ -26,6 +26,7 @@ namespace GRA.Domain.Model
         public const string ManageDailyLiteracyTips = "ManageDailyLiteracyTips";
         public const string ManageDashboardContent = "ManageDashboardContent";
         public const string ManageEvents = "ManageEvents";
+        public const string ManageGroupTypes = "ManageGroupTypes";
         public const string ManageLocations = "ManageLocations";
         public const string ManagePointTranslations = "ManagePointTranslations";
         public const string ManagePrograms = "ManagePrograms";

--- a/src/GRA.Domain.Model/SiteSettingFormat.cs
+++ b/src/GRA.Domain.Model/SiteSettingFormat.cs
@@ -2,6 +2,7 @@
 {
     public enum SiteSettingFormat
     {
-        Boolean
+        Boolean,
+        Integer
     }
 }

--- a/src/GRA.Domain.Repository/IGroupInfoRepository.cs
+++ b/src/GRA.Domain.Repository/IGroupInfoRepository.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace GRA.Domain.Repository
+{
+    public interface IGroupInfoRepository : IRepository<Model.GroupInfo>
+    {
+        Task<int> GetCountByTypeAsync(int groupTypeId);
+    }
+}

--- a/src/GRA.Domain.Repository/IGroupInfoRepository.cs
+++ b/src/GRA.Domain.Repository/IGroupInfoRepository.cs
@@ -5,5 +5,6 @@ namespace GRA.Domain.Repository
     public interface IGroupInfoRepository : IRepository<Model.GroupInfo>
     {
         Task<int> GetCountByTypeAsync(int groupTypeId);
+        Task<Model.GroupInfo> GetByUserIdAsync(int householdHeadUserId);
     }
 }

--- a/src/GRA.Domain.Repository/IGroupTypeRepository.cs
+++ b/src/GRA.Domain.Repository/IGroupTypeRepository.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using GRA.Domain.Model;
+
+namespace GRA.Domain.Repository
+{
+    public interface IGroupTypeRepository : IRepository<GroupType>
+    {
+        Task<(IEnumerable<GroupType>, int)> GetAllPagedAsync(int siteId, int skip, int take);
+    }
+}

--- a/src/GRA.Domain.Repository/IGroupTypeRepository.cs
+++ b/src/GRA.Domain.Repository/IGroupTypeRepository.cs
@@ -6,6 +6,7 @@ namespace GRA.Domain.Repository
 {
     public interface IGroupTypeRepository : IRepository<GroupType>
     {
+        Task<IEnumerable<GroupType>> GetAllForListAsync(int siteId);
         Task<(IEnumerable<GroupType>, int)> GetAllPagedAsync(int siteId, int skip, int take);
     }
 }

--- a/src/GRA.Domain.Service/GroupTypeService.cs
+++ b/src/GRA.Domain.Service/GroupTypeService.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using GRA.Abstract;
+using GRA.Domain.Model;
+using GRA.Domain.Repository;
+using GRA.Domain.Service.Abstract;
+using Microsoft.Extensions.Logging;
+
+namespace GRA.Domain.Service
+{
+    public class GroupTypeService : BaseUserService<GroupTypeService>
+    {
+        private readonly IGroupTypeRepository _groupTypeRepository;
+        private readonly IGroupInfoRepository _groupInfoRepository;
+        public GroupTypeService(ILogger<GroupTypeService> logger,
+            IDateTimeProvider dateTimeProvider,
+            IUserContextProvider userContextProvider,
+            IGroupInfoRepository groupInfoRepository,
+            IGroupTypeRepository groupTypeRepository)
+            : base(logger, dateTimeProvider, userContextProvider)
+        {
+            _groupInfoRepository = groupInfoRepository
+                ?? throw new ArgumentNullException(nameof(groupInfoRepository));
+            _groupTypeRepository = groupTypeRepository
+                ?? throw new ArgumentNullException(nameof(groupTypeRepository));
+            SetManagementPermission(Permission.ManageGroupTypes);
+        }
+
+        public async Task<DataWithCount<IEnumerable<GroupType>>> GetAllMCPagedAsync(int skip,
+            int take)
+        {
+            VerifyManagementPermission();
+            int siteId = GetCurrentSiteId();
+            var (list, count) = await _groupTypeRepository.GetAllPagedAsync(siteId, skip, take);
+            return new DataWithCount<IEnumerable<GroupType>>
+            {
+                Count = count,
+                Data = list
+            };
+        }
+
+        public async Task<(bool, string)> Add(int currentUserId, string groupTypeName)
+        {
+            VerifyManagementPermission();
+            if (string.IsNullOrEmpty(groupTypeName)
+                || string.IsNullOrEmpty(groupTypeName.Trim()))
+            {
+                throw new GraException("Please supply a group type name to add.");
+            }
+            try
+            {
+                await _groupTypeRepository.AddSaveAsync(currentUserId, new GroupType
+                {
+                    SiteId = GetCurrentSiteId(),
+                    Name = groupTypeName.Trim()
+                });
+                return (true, groupTypeName.Trim());
+            }
+            catch (Exception ex)
+            {
+                return (false, $"Unable to add group type: {ex.Message}");
+            }
+        }
+
+        public async Task<string> Remove(int currentUserId, int groupTypeId)
+        {
+            VerifyManagementPermission();
+
+            int usingThisType = 0;
+            try
+            {
+                usingThisType = await _groupInfoRepository.GetCountByTypeAsync(groupTypeId);
+            }
+            catch(Exception ex)
+            {
+                return $"Unable to remove group type - cannot tell if any groups are using it: {ex.Message}";
+            }
+
+            if(usingThisType > 0)
+            {
+                return $"Unable to remove group type - {usingThisType} groups currently have it selected.";
+            }
+
+            try
+            {
+                await _groupTypeRepository.RemoveSaveAsync(currentUserId, groupTypeId);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                return $"Unable to remove group type: {ex.Message}";
+            }
+        }
+
+        public async Task<(bool, string)> Edit(int currentUserId, int groupTypeId, string groupTypeName)
+        {
+            VerifyManagementPermission();
+            if (string.IsNullOrEmpty(groupTypeName)
+                || string.IsNullOrEmpty(groupTypeName.Trim()))
+            {
+                throw new GraException("Group types must have a name.");
+            }
+            try
+            {
+                var groupType = await _groupTypeRepository.GetByIdAsync(groupTypeId);
+                groupType.Name = groupTypeName.Trim();
+                await _groupTypeRepository.UpdateSaveAsync(currentUserId, groupType);
+                return (true, groupTypeName.Trim());
+            }
+            catch (Exception ex)
+            {
+                return (false, $"Unable to edit group type: {ex.Message}");
+            }
+        }
+
+    }
+}

--- a/src/GRA.Domain.Service/GroupTypeService.cs
+++ b/src/GRA.Domain.Service/GroupTypeService.cs
@@ -75,12 +75,12 @@ namespace GRA.Domain.Service
             }
             catch(Exception ex)
             {
-                return $"Unable to remove group type - cannot tell if any groups are using it: {ex.Message}";
+                return $"Unable to remove group type - cannot tell if any group(s) are using it: {ex.Message}";
             }
 
             if(usingThisType > 0)
             {
-                return $"Unable to remove group type - {usingThisType} groups currently have it selected.";
+                return $"Unable to remove group type - {usingThisType} group(s) currently have it selected.";
             }
 
             try

--- a/src/GRA.Domain.Service/UserService.cs
+++ b/src/GRA.Domain.Service/UserService.cs
@@ -844,6 +844,8 @@ namespace GRA.Domain.Service
             var headUser = await _userRepository.GetByIdAsync(user.HouseholdHeadUserId.Value);
             var household = await _userRepository.GetHouseholdAsync(user.HouseholdHeadUserId.Value);
 
+            int oldHeadUserId = headUser.Id;
+
             user.HouseholdHeadUserId = null;
             await _userRepository.UpdateSaveAsync(authId, user);
             headUser.HouseholdHeadUserId = user.Id;
@@ -856,6 +858,13 @@ namespace GRA.Domain.Service
                     await _userRepository.UpdateAsync(authId, member);
                 }
             }
+
+            var groupInfo = await _groupInfoRepository.GetByUserIdAsync(oldHeadUserId);
+            if(groupInfo != null)
+            {
+                groupInfo.UserId = user.Id;
+            }
+
             await _userRepository.SaveAsync();
         }
 

--- a/src/GRA.Domain.Service/UserService.cs
+++ b/src/GRA.Domain.Service/UserService.cs
@@ -17,6 +17,8 @@ namespace GRA.Domain.Service
         private readonly IBadgeRepository _badgeRepository;
         private readonly IBookRepository _bookRepository;
         private readonly IBranchRepository _branchRepository;
+        private readonly IGroupInfoRepository _groupInfoRepository;
+        private readonly IGroupTypeRepository _groupTypeRepository;
         private readonly IMailRepository _mailRepository;
         private readonly INotificationRepository _notificationRepository;
         private readonly IPrizeWinnerRepository _prizeWinnerRepository;
@@ -42,6 +44,8 @@ namespace GRA.Domain.Service
             IBadgeRepository badgeRepository,
             IBookRepository bookRepository,
             IBranchRepository branchRepository,
+            IGroupInfoRepository groupInfoRepository,
+            IGroupTypeRepository groupTypeRepository,
             IMailRepository mailRepository,
             INotificationRepository notificationRepository,
             IPrizeWinnerRepository prizeWinnerRepository,
@@ -67,6 +71,10 @@ namespace GRA.Domain.Service
             _badgeRepository = Require.IsNotNull(badgeRepository, nameof(badgeRepository));
             _bookRepository = Require.IsNotNull(bookRepository, nameof(bookRepository));
             _branchRepository = Require.IsNotNull(branchRepository, nameof(branchRepository));
+            _groupInfoRepository = groupInfoRepository
+                ?? throw new ArgumentNullException(nameof(groupInfoRepository));
+            _groupTypeRepository = groupTypeRepository
+                ?? throw new ArgumentNullException(nameof(groupTypeRepository));
             _mailRepository = Require.IsNotNull(mailRepository, nameof(mailRepository));
             _notificationRepository = Require.IsNotNull(notificationRepository,
                 nameof(notificationRepository));
@@ -86,9 +94,9 @@ namespace GRA.Domain.Service
             _configurationService = Require.IsNotNull(configurationService,
                 nameof(configurationService));
             _schoolService = Require.IsNotNull(schoolService, nameof(schoolService));
-            _siteLookupService = siteLookupService 
+            _siteLookupService = siteLookupService
                 ?? throw new ArgumentNullException(nameof(siteLookupService));
-            _vendorCodeService = vendorCodeService 
+            _vendorCodeService = vendorCodeService
                 ?? throw new ArgumentNullException(nameof(VendorCodeService));
         }
 
@@ -266,7 +274,8 @@ namespace GRA.Domain.Service
                     .GetSiteSettingBoolAsync(currentEntity.SiteId,
                     SiteSettingKey.Users.RestrictChangingSystemBranch);
 
-                if (!restrictChangingSystemBranch) {
+                if (!restrictChangingSystemBranch)
+                {
                     currentEntity.SystemId = userToUpdate.SystemId;
                     currentEntity.BranchId = userToUpdate.BranchId;
                 }
@@ -642,15 +651,17 @@ namespace GRA.Domain.Service
             await _notificationRepository.RemoveByUserId(GetActiveUserId());
         }
 
-        public async Task<string> AddParticipantToHouseholdAsync(string username, string password)
+        public async Task<(int totalAddCount, int addUserId)> 
+            CountParticipantsToAdd(string username, string password)
         {
             string trimmedUsername = username.Trim();
             VerifyCanHouseholdAction();
 
             var authUser = await _userRepository.GetByIdAsync(GetClaimId(ClaimType.UserId));
+
             if (authUser.HouseholdHeadUserId != null)
             {
-                throw new GraException("Only a household head can add members");
+                throw new GraException("Only a household or group manager can add members");
             }
 
             var authenticationResult = await _userRepository.AuthenticateUserAsync(trimmedUsername, password);
@@ -662,11 +673,36 @@ namespace GRA.Domain.Service
             {
                 throw new GraException("You cannot add yourself");
             }
-            bool hasFamily = false;
+
+            int totalAddCount = 0;
             if (authenticationResult.User.HouseholdHeadUserId == null)
             {
                 var household = await _userRepository
                     .GetHouseholdAsync(authenticationResult.User.Id);
+                totalAddCount = household.Count();
+            }
+
+            return (totalAddCount: totalAddCount, addUserId: authenticationResult.User.Id);
+        }
+
+        public async Task<string> AddParticipantToHouseholdAlreadyAuthorizedAsync(int userId)
+        {
+            VerifyCanHouseholdAction();
+
+            var authUser = await _userRepository.GetByIdAsync(GetClaimId(ClaimType.UserId));
+
+            if (authUser.HouseholdHeadUserId != null)
+            {
+                throw new GraException("Only a household or group manager can add members");
+            }
+
+            var user = await _userRepository.GetByIdAsync(userId);
+
+            bool hasFamily = false;
+            if (user.HouseholdHeadUserId == null)
+            {
+                var household = await _userRepository
+                    .GetHouseholdAsync(user.Id);
                 foreach (var member in household)
                 {
                     hasFamily = true;
@@ -674,14 +710,55 @@ namespace GRA.Domain.Service
                     await _userRepository.UpdateSaveAsync(authUser.Id, member);
                 }
             }
-            authenticationResult.User.HouseholdHeadUserId = authUser.Id;
-            await _userRepository.UpdateSaveAsync(authUser.Id, authenticationResult.User);
-            string addedMembers = authenticationResult.User.FullName;
+
+            var isGroup = await _groupInfoRepository.GetByUserIdAsync(authUser.Id);
+            var callIt = isGroup != null ? "group" : "household";
+
+            if (hasFamily == true)
+            {
+                var infoGroup
+                    = await _groupInfoRepository.GetByUserIdAsync(user.Id);
+                if (infoGroup != null)
+                {
+                    _logger.LogInformation($"Existing {callIt} manager {user.Id} is is added to new head {authUser.Id}, group {infoGroup.Id}/{infoGroup.Name} is being removed.");
+                    await _groupInfoRepository.RemoveSaveAsync(authUser.Id, infoGroup.Id);
+                }
+            }
+
+            user.HouseholdHeadUserId = authUser.Id;
+            await _userRepository.UpdateSaveAsync(authUser.Id, user);
+            string addedMembers = user.FullName;
             if (hasFamily)
             {
-                addedMembers += " and their household";
+                addedMembers += $" and their {callIt}";
             }
             return addedMembers;
+        }
+
+
+        public async Task<string> AddParticipantToHouseholdAsync(string username, string password)
+        {
+            VerifyCanHouseholdAction();
+
+            var authUser = await _userRepository.GetByIdAsync(GetClaimId(ClaimType.UserId));
+
+            if (authUser.HouseholdHeadUserId != null)
+            {
+                throw new GraException("Only a household or group manager can add members");
+            }
+
+            string trimmedUsername = username.Trim();
+            var authenticationResult = await _userRepository.AuthenticateUserAsync(trimmedUsername, password);
+            if (!authenticationResult.PasswordIsValid)
+            {
+                throw new GraException("The username and password entered do not match");
+            }
+            if (authenticationResult.User.Id == authUser.Id)
+            {
+                throw new GraException("You cannot add yourself");
+            }
+
+            return await AddParticipantToHouseholdAlreadyAuthorizedAsync(authenticationResult.User.Id);
         }
 
         public async Task<IEnumerable<User>> GetHouseholdAsync(int householdHeadUserId,
@@ -749,20 +826,20 @@ namespace GRA.Domain.Service
             var authId = GetClaimId(ClaimType.UserId);
             if (!HasPermission(Permission.EditParticipants))
             {
-                _logger.LogError($"User {authId} doesn't have permission to promote household members to head.");
+                _logger.LogError($"User {authId} doesn't have permission to promote household/group members to head.");
                 throw new GraException("Permission denied.");
             }
 
             var user = await _userRepository.GetByIdAsync(userId); ;
             if (string.IsNullOrWhiteSpace(user.Username))
             {
-                _logger.LogError($"User {userId} cannot be promoted to head of household without a username.");
+                _logger.LogError($"User {userId} cannot be promoted to household/group manager without a username.");
                 throw new GraException("User does not have a username.");
             }
             if (!user.HouseholdHeadUserId.HasValue)
             {
-                _logger.LogError($"User {userId} cannot be promoted to head of household.");
-                throw new GraException("User does not have a household or is already the head.");
+                _logger.LogError($"User {userId} cannot be promoted to household/group manager.");
+                throw new GraException("User does not have a group/household or is already the manager.");
             }
             var headUser = await _userRepository.GetByIdAsync(user.HouseholdHeadUserId.Value);
             var household = await _userRepository.GetHouseholdAsync(user.HouseholdHeadUserId.Value);
@@ -789,20 +866,20 @@ namespace GRA.Domain.Service
             var authId = GetClaimId(ClaimType.UserId);
             if (!HasPermission(Permission.EditParticipants))
             {
-                _logger.LogError($"User {authId} doesn't have permission to remove household members.");
+                _logger.LogError($"User {authId} doesn't have permission to remove household/group members.");
                 throw new GraException("Permission denied.");
             }
 
             var user = await _userRepository.GetByIdAsync(userId);
             if (string.IsNullOrWhiteSpace(user.Username))
             {
-                _logger.LogError($"User {userId} cannot be removed from a household without a username.");
+                _logger.LogError($"User {userId} cannot be removed from a household/group without a username.");
                 throw new GraException("Participant does not have a username.");
             }
             if (!user.HouseholdHeadUserId.HasValue)
             {
-                _logger.LogError($"User {userId} cannot be removed from a household.");
-                throw new GraException("Participant does not have a household or is the head.");
+                _logger.LogError($"User {userId} cannot be removed from a household/group.");
+                throw new GraException("Participant does not have a household/group or is the manager.");
             }
             user.HouseholdHeadUserId = null;
             await _userRepository.UpdateSaveAsync(authId, user);
@@ -815,15 +892,15 @@ namespace GRA.Domain.Service
             var authId = GetClaimId(ClaimType.UserId);
             if (!HasPermission(Permission.EditParticipants))
             {
-                _logger.LogError($"User {authId} doesn't add existing participants to household.");
+                _logger.LogError($"User {authId} doesn't add existing participants to household/group.");
                 throw new GraException("Permission denied.");
             }
             var userToAdd = await _userRepository.GetByIdAsync(userToAddId);
             if (userToAdd.HouseholdHeadUserId.HasValue
                 || (await _userRepository.GetHouseholdCountAsync(userToAddId)) > 0)
             {
-                _logger.LogError($"User {authId} cannot add {userToAddId} to a different household.");
-                throw new GraException("Participant already belongs to a household.");
+                _logger.LogError($"User {authId} cannot add {userToAddId} to a different household/group.");
+                throw new GraException("Participant already belongs to a household/group.");
             }
             var user = await _userRepository.GetByIdAsync(householdId);
             userToAdd.HouseholdHeadUserId = user.HouseholdHeadUserId ?? user.Id;
@@ -895,6 +972,38 @@ namespace GRA.Domain.Service
                     throw new GraException("Invalid School selection.");
                 }
             }
+        }
+
+        public async Task<GroupInfo> GetGroupFromHouseholdHeadAsync(int householdHeadUserId)
+        {
+            return await _groupInfoRepository.GetByUserIdAsync(householdHeadUserId);
+        }
+
+        public async Task<IEnumerable<GroupType>> GetGroupTypeListAsync()
+        {
+            return await _groupTypeRepository.GetAllForListAsync(GetCurrentSiteId());
+        }
+
+        public async Task<GroupInfo> CreateGroup(int currentUserId,
+            GroupInfo groupInfo)
+        {
+            var sanitizedGroupInfo = new GroupInfo
+            {
+                Name = groupInfo.Name,
+                GroupTypeId = groupInfo.GroupTypeId,
+                UserId = groupInfo.UserId
+            };
+
+            return await _groupInfoRepository.AddSaveAsync(currentUserId, groupInfo);
+        }
+
+        public async Task<GroupInfo> UpdateGroupName(int currentUserId, GroupInfo groupInfo)
+        {
+            var currentGroup = await _groupInfoRepository.GetByUserIdAsync(groupInfo.UserId);
+            currentGroup.Name = groupInfo.Name;
+            currentGroup.GroupType = null;
+            currentGroup.User = null;
+            return await _groupInfoRepository.UpdateSaveAsync(currentUserId, currentGroup);
         }
     }
 }

--- a/src/GRA.Web/Areas/MissionControl/Views/GroupTypes/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/GroupTypes/Index.cshtml
@@ -1,6 +1,50 @@
 ﻿@model GRA.Controllers.ViewModel.MissionControl.GroupTypes.GroupTypesListViewModel
 
-<div class="row row-spacing" style="margin-top: 1rem;">
+@if (Model.MaximumHouseholdMembers == null)
+{
+    <div class="row row-spacing" style="margin-top: 1rem;">
+        <div class="col-sm-8 col-sm-offset-2">
+            <div class="alert alert-danger">
+                <table>
+                    <tr>
+                        <td>
+                            <span class="fa fa-exclamation-triangle fa-2x pull-left"
+                                  style="padding-right: 1rem;"></span>
+                        </td>
+                        <td>
+                            No maximum number of household members is configured for this site so
+                            groups will not be used even if group types are configured below.
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+}
+else
+{
+    <div class="row row-spacing" style="margin-top: 1rem;">
+        <div class="col-sm-8 col-sm-offset-2">
+            <div class="alert alert-info">
+                <table>
+                    <tr>
+                        <td>
+                            <span class="fa fa-info-circle fa-2x pull-left"
+                                  style="padding-right: 1rem;"></span>
+                        </td>
+                        <td>
+                            Households will be prompted to upgrade to a group when they exceed
+                            <strong>@Model.MaximumHouseholdMembers members</strong> and one or more
+                            group types are configured below.
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+}
+
+<div class="row row-spacing">
     <div class="col-xs-12">
         <a class="btn btn-default"
            data-toggle="modal"

--- a/src/GRA.Web/Areas/MissionControl/Views/GroupTypes/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/GroupTypes/Index.cshtml
@@ -17,7 +17,12 @@
         {
             <div class="alert alert-warning">
                 No group types configured.
-                <a data-toggle="modal" data-target="#addModal">Add a group type</a>.
+                <a class="btn btn-default"
+                   data-toggle="modal"
+                   data-target="#addModal">
+                    <span class="fa fa-plus-circle"></span>
+                    Add a group type
+                </a>
             </div>
         }
         else
@@ -33,7 +38,7 @@
                     <tbody>
                         @foreach (var groupType in Model.GroupTypes)
                         {
-                            <tr>
+                            <tr data-id="@groupType.Id" data-name="@groupType.Name">
                                 <td>
                                     @groupType.Name
                                 </td>
@@ -41,18 +46,14 @@
                                     <button type="submit"
                                             class="btn btn-primary btn-xs"
                                             data-toggle="modal"
-                                            data-target="#editModal"
-                                            data-id="@groupType.Id"
-                                            data-name="@groupType.Name">
+                                            data-target="#editModal">
                                         <span class="fa fa-pencil" aria-hidden="true"></span>
                                     </button>
                                     <button type="button"
                                             class="btn btn-danger btn-xs"
                                             style="margin-left:16px;"
                                             data-toggle="modal"
-                                            data-target="#deleteModal"
-                                            data-id="@groupType.Id"
-                                            data-name="@groupType.Name">
+                                            data-target="#deleteModal">
                                         <span class="fa fa-remove" aria-hidden="true"></span>
                                     </button>
                                 </td>
@@ -165,19 +166,25 @@
         });
 
         $('#deleteModal').on('show.bs.modal', function (event) {
-            var button = $(event.relatedTarget);
-            var name = button.data('name');
+            var dataElement = $(event.relatedTarget).closest('[data-id]');
+            var name = dataElement.data('name');
             $('#deleteModalText').text('Are you sure you wish to delete the group type: ' + name + '?');
-            $('#deleteGroupTypeId').val(button.data('id'));
+            $('#deleteGroupTypeId').val(dataElement.data('id'));
             $('#deleteGroupTypeName').val(name);
         });
 
         $('#editModal').on('show.bs.modal', function (event) {
-            var button = $(event.relatedTarget);
-            var name = button.data('name');
+            console.log(event);
+            console.log($(event.relatedTarget));
+            var dataElement = $(event.relatedTarget).closest('[data-id]');
+            var name = dataElement.data('name');
             $('#editModalLabel').text("Edit group type: " + name);
-            $('#editGroupTypeId').val(button.data('id'));
+            $('#editGroupTypeId').val(dataElement.data('id'));
             $('#editGroupTypeName').val(name);
+        });
+
+        $('#editModal').on('shown.bs.modal', function (event) {
+            $('#editGroupTypeName').focus();
         });
     </script>
 }

--- a/src/GRA.Web/Areas/MissionControl/Views/GroupTypes/Index.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/GroupTypes/Index.cshtml
@@ -1,0 +1,183 @@
+﻿@model GRA.Controllers.ViewModel.MissionControl.GroupTypes.GroupTypesListViewModel
+
+<div class="row row-spacing" style="margin-top: 1rem;">
+    <div class="col-xs-12">
+        <a class="btn btn-default"
+           data-toggle="modal"
+           data-target="#addModal">
+            <span class="fa fa-plus-circle"></span>
+            Add a group type
+        </a>
+    </div>
+</div>
+
+<div class="row row-spacing">
+    <div class="col-xs-12">
+        @if (Model.GroupTypes.Count() == 0)
+        {
+            <div class="alert alert-warning">
+                No group types configured.
+                <a data-toggle="modal" data-target="#addModal">Add a group type</a>.
+            </div>
+        }
+        else
+        {
+            <div>
+                <table class="table table-condensed table-bordered table-striped">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th style="width: 9rem;">&nbsp;</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var groupType in Model.GroupTypes)
+                        {
+                            <tr>
+                                <td>
+                                    @groupType.Name
+                                </td>
+                                <td class="gra-mc-icon">
+                                    <button type="submit"
+                                            class="btn btn-primary btn-xs"
+                                            data-toggle="modal"
+                                            data-target="#editModal"
+                                            data-id="@groupType.Id"
+                                            data-name="@groupType.Name">
+                                        <span class="fa fa-pencil" aria-hidden="true"></span>
+                                    </button>
+                                    <button type="button"
+                                            class="btn btn-danger btn-xs"
+                                            style="margin-left:16px;"
+                                            data-toggle="modal"
+                                            data-target="#deleteModal"
+                                            data-id="@groupType.Id"
+                                            data-name="@groupType.Name">
+                                        <span class="fa fa-remove" aria-hidden="true"></span>
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+            @if (Model.PaginateModel.MaxPage > 1)
+            {
+                <paginate paginateModel="@Model.PaginateModel"></paginate>
+            }
+        }
+    </div>
+</div>
+
+<div class="modal fade" id="addModal" tabindex="-1" role="dialog" aria-labelledby="addModalLabel">
+    <div class="modal-dialog" role="document">
+        <form asp-controller="GroupTypes" asp-action="Add" method="post" role="form" style="display:inline">
+            <input type="hidden" asp-for="PaginateModel.CurrentPage" id="AddCurrentPage" />
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="addModalLabel">Add group type</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label asp-for="GroupType.Name" class="control-label"></label>
+                        <input asp-for="GroupType.Name" id="addGroupTypeName" class="form-control" />
+                        <span asp-validation-for="GroupType.Name" class="text-danger"></span>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal" style="margin-right: 1em;">Cancel</button>
+                    <button type="submit" class="btn btn-primary btn-spinner pull-right" aria-label="Confirm">
+                        Add
+                        <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="deleteModalLabel">Delete group type</h4>
+            </div>
+            <div class="modal-body">
+                <span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
+                <span id="deleteModalText"></span>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal" style="margin-right: 1em;">Cancel</button>
+                <form asp-controller="GroupTypes" asp-action="Delete" method="post" role="form" style="display:inline">
+                    <input type="hidden" asp-for="PaginateModel.CurrentPage" id="DeleteCurrentPage" />
+                    <input asp-for="GroupType.Id" id="deleteGroupTypeId" type="hidden" />
+                    <input asp-for="GroupType.Name" id="deleteGroupTypeName" type="hidden" />
+                    <button type="submit" class="btn btn-danger btn-spinner pull-right" aria-label="Confirm">
+                        <span class="fa fa-remove" aria-hidden="true"></span>
+                        Delete
+                        <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="modal fade" id="editModal" tabindex="-1" role="dialog" aria-labelledby="editModalLabel">
+        <div class="modal-dialog" role="document">
+            <form asp-controller="GroupTypes" asp-action="Edit" method="post" role="form" style="display:inline">
+                <input type="hidden" asp-for="PaginateModel.CurrentPage" id="EditCurrentPage" />
+                <input asp-for="GroupType.Id" id="editGroupTypeId" type="hidden" />
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title" id="editModalLabel">Edit group type</h4>
+                    </div>
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label asp-for="GroupType.Name" class="control-label"></label>
+                            <input asp-for="GroupType.Name" id="editGroupTypeName" class="form-control" />
+                            <span asp-validation-for="GroupType.Name" class="text-danger"></span>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal" style="margin-right: 1em;">Cancel</button>
+                        <button type="submit" class="btn btn-primary btn-spinner pull-right" aria-label="Confirm">
+                            Save
+                            <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+
+@section scripts
+    {
+    <script>
+        $('#addModal').on('shown.bs.modal', function (event) {
+            $('#addGroupTypeName').focus();
+        });
+
+        $('#deleteModal').on('show.bs.modal', function (event) {
+            var button = $(event.relatedTarget);
+            var name = button.data('name');
+            $('#deleteModalText').text('Are you sure you wish to delete the group type: ' + name + '?');
+            $('#deleteGroupTypeId').val(button.data('id'));
+            $('#deleteGroupTypeName').val(name);
+        });
+
+        $('#editModal').on('show.bs.modal', function (event) {
+            var button = $(event.relatedTarget);
+            var name = button.data('name');
+            $('#editModalLabel').text("Edit group type: " + name);
+            $('#editGroupTypeId').val(button.data('id'));
+            $('#editGroupTypeName').val(name);
+        });
+    </script>
+}

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/Household.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/Household.cshtml
@@ -112,7 +112,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="promoteModalLabel">Promote to Head of Household</h4>
+                        <h4 class="modal-title" id="promoteModalLabel">Promote to Manager</h4>
                     </div>
                     <div class="modal-body">
                         <span class="fa fa-exclamation-circle" aria-hidden="true"></span>
@@ -140,7 +140,7 @@
                 <div class="modal-content">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="deleteModalLabel">Remove from household</h4>
+                        <h4 class="modal-title" id="deleteModalLabel">Remove from household/group</h4>
                     </div>
                     <div class="modal-body">
                         <span class="fa fa-exclamation-triangle" aria-hidden="true"></span>
@@ -167,7 +167,7 @@
     <div class="col-xs-12">
         @if (Model.Users.Count() == 0)
         {
-            <div class="alert alert-warning">Participant is not a member of a household</div>
+            <div class="alert alert-warning">Participant is not a member of a household/group</div>
         }
         else
         {
@@ -541,8 +541,10 @@
                                                         data-toggle="modal"
                                                         data-target="#promoteModal"
                                                         data-id="@user.Id"
-                                                        data-name="@user.FullName">
-                                                    <span class="fa fa-level-up" aria-hidden="true"></span>
+                                                        data-name="@user.FullName"
+                                                        title="Promote to household/group manager">
+                                                    <span class="fa fa-level-up" 
+                                                          aria-hidden="true"></span>
                                                 </button>
                                                 <button type="button"
                                                         class="btn btn-danger btn-xs"
@@ -550,8 +552,10 @@
                                                         data-toggle="modal"
                                                         data-target="#removeModal"
                                                         data-id="@user.Id"
-                                                        data-name="@user.FullName">
-                                                    <span class="fa fa-minus" aria-hidden="true"></span>
+                                                        data-name="@user.FullName"
+                                                        title="Remove from household/group">
+                                                    <span class="fa fa-minus" 
+                                                          aria-hidden="true"></span>
                                                 </button>
                                             }
                                             else

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/Household.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/Household.cshtml
@@ -163,6 +163,16 @@
     </div>
 }
 
+@if (!string.IsNullOrEmpty(Model.GroupName))
+{
+    <div class="row" style="padding: 10px 0; font-size: larger;">
+        <div class="col-xs-12">
+            <strong>Group name:</strong> @Model.GroupName<br />
+            <strong>Group type:</strong> @Model.GroupType
+        </div>
+    </div>
+}
+
 <div class="row" style="padding: 10px 0;">
     <div class="col-xs-12">
         @if (Model.Users.Count() == 0)
@@ -543,7 +553,7 @@
                                                         data-id="@user.Id"
                                                         data-name="@user.FullName"
                                                         title="Promote to household/group manager">
-                                                    <span class="fa fa-level-up" 
+                                                    <span class="fa fa-level-up"
                                                           aria-hidden="true"></span>
                                                 </button>
                                                 <button type="button"
@@ -554,7 +564,7 @@
                                                         data-id="@user.Id"
                                                         data-name="@user.FullName"
                                                         title="Remove from household/group">
-                                                    <span class="fa fa-minus" 
+                                                    <span class="fa fa-minus"
                                                           aria-hidden="true"></span>
                                                 </button>
                                             }
@@ -653,8 +663,15 @@
     <a asp-action="Index" class="btn btn-default">Return to Participants</a>
     @if (Model.CanEditDetails)
     {
-        <a asp-action="AddHouseholdMember" asp-route-id="@Model.Id" class="btn btn-default">Add Household Member</a>
-        <button type="button" class="btn btn-default" data-toggle="modal" data-target="#listModal">Add Existing Participant</button>
+        if (Model.UpgradeToGroup)
+        {
+            <a asp-action="UpgradeToGroup" asp-route-id="@Model.Id" class="btn btn-default">Upgrade to Group to add more members</a>
+        }
+        else
+        {
+            <a asp-action="AddHouseholdMember" asp-route-id="@Model.Id" class="btn btn-default">Add Household Member</a>
+            <button type="button" class="btn btn-default" data-toggle="modal" data-target="#listModal">Add Existing Participant</button>
+        }
     }
 </div>
 

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/Household.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/Household.cshtml
@@ -166,7 +166,14 @@
 @if (!string.IsNullOrEmpty(Model.GroupName))
 {
     <div class="row" style="padding: 10px 0; font-size: larger;">
-        <div class="col-xs-12">
+        @if (Model.CanEditDetails)
+        {
+            <div class="col-sm-2">
+                <a href="@Url.Action(" UpdateGroup", new { id=Model.HeadOfHouseholdId ?? Model.Id })"
+                   class="btn btn-block btn-default">Edit Group</a>
+            </div>
+        }
+        <div class="col-sm-10">
             <strong>Group name:</strong> @Model.GroupName<br />
             <strong>Group type:</strong> @Model.GroupType
         </div>
@@ -197,11 +204,11 @@
                                     {
                                         <td style="padding-right:6px;">@Model.PointTranslation.TranslationDescriptionPastTense.Replace("{0}", "").Trim()</td>
                                         <td width="80px" style="padding-right:6px;">
-                                            <input data-action="@Url.Action("HouseholdApplyActivity")" value="" class="form-control activityInput" />
+                                            <input data-action="@Url.Action(" HouseholdApplyActivity")" value="" class="form-control activityInput" />
                                         </td>
                                     }
                                     <td>
-                                        <button type="submit" class="btn btn-primary btn-spinner activityButton" data-action="@Url.Action("HouseholdApplyActivity")">
+                                        <button type="submit" class="btn btn-primary btn-spinner activityButton" data-action="@Url.Action(" HouseholdApplyActivity")">
                                             <span>
                                                 @if (Model.PointTranslation.IsSingleEvent)
                                                 {
@@ -240,10 +247,10 @@
                                     <tr>
                                         <td style="padding-right:6px;">Apply</td>
                                         <td width="200px">
-                                            <input data-action="@Url.Action("HouseholdApplySecretCode")" class="form-control codeInput" />
+                                            <input data-action="@Url.Action(" HouseholdApplySecretCode")" class="form-control codeInput" />
                                         </td>
                                         <td style="padding-left:6px;">
-                                            <button type="submit" class="btn btn-primary btn-spinner codeButton" data-action="@Url.Action("HouseholdApplySecretCode")">
+                                            <button type="submit" class="btn btn-primary btn-spinner codeButton" data-action="@Url.Action(" HouseholdApplySecretCode")">
                                                 <span class="buttonText">Secret Code</span>
                                                 <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
                                             </button>
@@ -290,7 +297,7 @@
                                     <th width="80px">&nbsp;</th>
                                 }
                             </tr>
-                            <tr class="warning @(Model.Id == Model.Head.Id ? "text-strong" : null)">
+                            <tr class="warning @(Model.Id == Model.Head.Id ? " text-strong" : null)">
                                 @if (Model.CanLogActivity)
                                 {
                                     <td class="on-top" style="vertical-align:middle;">
@@ -384,7 +391,7 @@
                                                 <strong>@Model.Head.VendorCode</strong>
                                             }
                                             if (@Model.Head.Donated == true
-                                                && User.HasClaim(ClaimType.Permission, Permission.PerformDrawing.ToString()))
+                                            && User.HasClaim(ClaimType.Permission, Permission.PerformDrawing.ToString()))
                                             {
                                                 <button class="btn btn-info btn-xs btn-spinner btn-on-top"
                                                         name="undonateButton"
@@ -413,7 +420,7 @@
                         <tbody>
                             @foreach (var user in Model.Users)
                             {
-                                <tr class="@(Model.Id == user.Id ? "info text-strong" : null)">
+                                <tr class="@(Model.Id == user.Id ? " info text-strong" : null)">
                                     @if (Model.CanLogActivity)
                                     {
                                         <td class="on-top" style="vertical-align:middle;">
@@ -590,11 +597,11 @@
                                     {
                                         <td style="padding-right:6px;">@Model.PointTranslation.TranslationDescriptionPastTense.Replace("{0}", "").Trim()</td>
                                         <td width="80px" style="padding-right:6px;">
-                                            <input data-action="@Url.Action("HouseholdApplyActivity")" value="" class="form-control activityInput" />
+                                            <input data-action="@Url.Action(" HouseholdApplyActivity")" value="" class="form-control activityInput" />
                                         </td>
                                     }
                                     <td>
-                                        <button type="submit" class="btn btn-primary btn-spinner activityButton" data-action="@Url.Action("HouseholdApplyActivity")">
+                                        <button type="submit" class="btn btn-primary btn-spinner activityButton" data-action="@Url.Action(" HouseholdApplyActivity")">
                                             <span>
                                                 @if (Model.PointTranslation.IsSingleEvent)
                                                 {
@@ -633,10 +640,10 @@
                                     <tr>
                                         <td style="padding-right:6px;">Apply</td>
                                         <td width="200px">
-                                            <input data-action="@Url.Action("HouseholdApplySecretCode")" class="form-control codeInput" />
+                                            <input data-action="@Url.Action(" HouseholdApplySecretCode")" class="form-control codeInput" />
                                         </td>
                                         <td style="padding-left:6px;">
-                                            <button type="submit" class="btn btn-primary btn-spinner codeButton" data-action="@Url.Action("HouseholdApplySecretCode")">
+                                            <button type="submit" class="btn btn-primary btn-spinner codeButton" data-action="@Url.Action(" HouseholdApplySecretCode")">
                                                 <span class="buttonText">Secret Code</span>
                                                 <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
                                             </button>
@@ -678,248 +685,259 @@
 @section scripts
     {
     <script>
-        $(document).ready(function() {
-            $('.td-class').each(function() {
-                $(this).children('a.rowlink').height($(this).height() + 11);
-            });
+    $(document).ready(function () {
+        $('.td-class').each(function () {
+            $(this).children('a.rowlink').height($(this).height() + 11);
         });
-        $(window).resize(function() {
-            $('.td-class').each(function() {
-                $(this).children('a.rowlink').height($(this).height() + 11);
-            });
+    });
+    $(window).resize(function () {
+        $('.td-class').each(function () {
+            $(this).children('a.rowlink').height($(this).height() + 11);
         });
+    });
 
-        @if (Model.CanLogActivity) {
-        <text>
-        var submitting = false;
+    /**/
+@if (Model.CanLogActivity)
+    {
+<text>
+    /**/
+    var submitting = false;
 
-        $("#checkAll").on("change", function(e) {
-            if (e.originalEvent)
-            {
-                $(".userSelection").prop("checked", $(this).prop("checked"));
-            }
-        });
-
-        $(".userSelection").on("change", function(e) {
-            if (e.originalEvent)
-            {
-                if ($(".userSelection:not(:checked)").length)
-                {
-                    $("#checkAll").prop("checked", false);
-                }
-                else
-                {
-                    $("#checkAll").prop("checked", true);
-                }
-            }
-        });
-
-        $(".activityInput").on("keypress", function(e) {
-            var keyCode = e.keyCode || e.which;
-            if (keyCode === 13)
-            {
-                e.preventDefault();
-                if (submitting != true) {
-                    submitting = true;
-                    $("#ActivityAmount").val($(this).val());
-                    SetUserSelection();
-                    $("#form").attr("action", $(this).data("action")).submit();
-                }
-            }
-        });
-
-        $(".codeInput").on("keypress", function(e) {
-            var keyCode = e.keyCode || e.which;
-            if (keyCode === 13)
-            {
-                e.preventDefault();
-                if (submitting != true) {
-                    submitting = true;
-                    $("#SecretCode").val($(this).val());
-                    SetUserSelection();
-                    $("#form").attr("action", $(this).data("action")).submit();
-                }
-            }
-        });
-
-        $(".activityButton").on("click", function(e) {
-            e.preventDefault();
-            if (submitting != true) {
-                submitting = true;
-                $("#ActivityAmount").val($(this).parent().parent().find(".activityInput").val());
-                SetUserSelection();
-                $("#form").attr("action", $(this).data("action")).submit();
-            }
-        });
-
-        $(".codeButton").on("click", function(e) {
-            e.preventDefault();
-            if (submitting != true) {
-                submitting = true;
-                $("#SecretCode").val($(this).parent().parent().find(".codeInput").val());
-                SetUserSelection();
-                $("#form").attr("action", $(this).data("action")).submit();
-            }
-        });
-
-        function SetUserSelection() {
-            var selectionArray = [];
-            $(".userSelection:checked").each(function() {
-                selectionArray.push($(this).data("id"));
-            });
-            $("#UserSelection").val(selectionArray);
-        };
-        </text>
+    $("#checkAll").on("change", function (e) {
+        if (e.originalEvent) {
+            $(".userSelection").prop("checked", $(this).prop("checked"));
         }
+    });
 
-        @if (Model.CanEditDetails)
-        {
-        <text>
-        var userId = @Model.Id
-        var defaultSystemId = @Model.SystemId;
-        var participantsUrl = "@Url.Action("HouseholdGetParticipantsList")";
-        var branchUrl = "@Url.Action("GetBranches", "Lookup", new { Area = string.Empty })";
-        var systemId = null;
-        var branchId = null;
-        var search = "";
-        var page = 1;
-
-        function UpdateParticipantsList() {
-            $.get(participantsUrl,
-                {
-                    userId: userId,
-                    systemId: systemId,
-                    branchId: branchId,
-                    search: search,
-                    page: page
-                }, function(response) {
-                    $("#modalParticipantsList").html(response);
-                });
-        }
-
-        function UpdateBranchList(system) {
-            $.get(branchUrl,
-                {
-                    systemId: system,
-                    branchId: null,
-                    prioritize: true
-                }, function(response) {
-                    $("#branchDropdown").empty();
-                    $.each(response, function(index, item) {
-                        $("#branchDropdown").append('<li><a class="branch-selector" data-id="' + item.value + '">' + item.text+ '</a></li>');
-                    });
-                });
-        }
-
-        $('#listModal').on('show.bs.modal', function() {
-            UpdateParticipantsList();
-        })
-
-        $("#All").on("click", function() {
-            if (systemId != null) {
-                $(this).siblings().removeClass("active");
-                $(this).addClass().addClass("active");
-                $("#systemText").text("System");
-                $("#branchText").text("Branch");
-                if (systemId != defaultSystemId) {
-                    UpdateBranchList(defaultSystemId);
-                }
-                systemId = null;
-                branchId = null;
-                page = 1;
-                UpdateParticipantsList();
-            }
-        });
-
-        $(".system-selector").on("click", function(e) {
-            var thisId = $(this).data("id");
-            if (systemId != thisId || branchId != null) {
-                if (systemId == null || branchId != null) {
-                    var navPill = $(this).parent().parent().parent();
-                    navPill.siblings().removeClass("active");
-                    navPill.addClass().addClass("active");
-                    if (branchId != null) {
-                        $("#branchText").text("Branch");
-                    }
-                }
-                $("#systemText").text($(this).text());
-                if (systemId != thisId && (systemId != null || thisId != defaultSystemId)) {
-                    UpdateBranchList(thisId);
-                }
-                systemId = thisId;
-                branchId = null;
-                page = 1;
-                UpdateParticipantsList();
-            }
-        });
-
-        $(document).on("click", ".branch-selector", function(e) {
-            var thisId = $(this).data("id");
-            if (branchId != thisId) {
-                if (branchId == null) {
-                    var navPill = $(this).parent().parent().parent();
-                    navPill.siblings().removeClass("active");
-                    navPill.addClass().addClass("active");
-                    if (systemId == null) {
-                        systemId = defaultSystemId;
-                        $("#systemText").text($(".system-selector").first().text());
-                    }
-                }
-                $("#branchText").text($(this).text());
-                branchId = thisId;
-                page = 1;
-                UpdateParticipantsList();
-            }
-        });
-
-        $("#searchButton").on("click", function () {
-            search = $("#searchText").val();
-            if (search != "") {
-                $("#searchMessage").removeClass("hide");
-                $("#searchTerm").html(search);
+    $(".userSelection").on("change", function (e) {
+        if (e.originalEvent) {
+            if ($(".userSelection:not(:checked)").length) {
+                $("#checkAll").prop("checked", false);
             }
             else {
-                $("#searchMessage").addClass("hide");
+                $("#checkAll").prop("checked", true);
             }
+        }
+    });
+
+    $(".activityInput").on("keypress", function (e) {
+        var keyCode = e.keyCode || e.which;
+        if (keyCode === 13) {
+            e.preventDefault();
+            if (submitting != true) {
+                submitting = true;
+                $("#ActivityAmount").val($(this).val());
+                SetUserSelection();
+                $("#form").attr("action", $(this).data("action")).submit();
+            }
+        }
+    });
+
+    $(".codeInput").on("keypress", function (e) {
+        var keyCode = e.keyCode || e.which;
+        if (keyCode === 13) {
+            e.preventDefault();
+            if (submitting != true) {
+                submitting = true;
+                $("#SecretCode").val($(this).val());
+                SetUserSelection();
+                $("#form").attr("action", $(this).data("action")).submit();
+            }
+        }
+    });
+
+    $(".activityButton").on("click", function (e) {
+        e.preventDefault();
+        if (submitting != true) {
+            submitting = true;
+            $("#ActivityAmount").val($(this).parent().parent().find(".activityInput").val());
+            SetUserSelection();
+            $("#form").attr("action", $(this).data("action")).submit();
+        }
+    });
+
+    $(".codeButton").on("click", function (e) {
+        e.preventDefault();
+        if (submitting != true) {
+            submitting = true;
+            $("#SecretCode").val($(this).parent().parent().find(".codeInput").val());
+            SetUserSelection();
+            $("#form").attr("action", $(this).data("action")).submit();
+        }
+    });
+
+    function SetUserSelection() {
+        var selectionArray = [];
+        $(".userSelection:checked").each(function () {
+            selectionArray.push($(this).data("id"));
+        });
+        $("#UserSelection").val(selectionArray);
+    };
+    /**/
+</text>
+}
+    /**/
+
+    /**/
+@if (Model.CanEditDetails)
+    {
+<text>
+    /**/
+    /**/
+    var userId = @Model.Id
+/**/
+/**/
+        var defaultSystemId = @Model.SystemId;
+        /**/
+        /**/
+        var participantsUrl = "@Url.Action("HouseholdGetParticipantsList")";
+    /**/
+    /**/
+    var branchUrl = "@Url.Action("GetBranches", "Lookup", new { Area = string.Empty })";
+    /**/
+    var systemId = null;
+    var branchId = null;
+    var search = "";
+    var page = 1;
+
+    function UpdateParticipantsList() {
+        $.get(participantsUrl,
+            {
+                userId: userId,
+                systemId: systemId,
+                branchId: branchId,
+                search: search,
+                page: page
+            }, function (response) {
+                $("#modalParticipantsList").html(response);
+            });
+    }
+
+    function UpdateBranchList(system) {
+        $.get(branchUrl,
+            {
+                systemId: system,
+                branchId: null,
+                prioritize: true
+            }, function (response) {
+                $("#branchDropdown").empty();
+                $.each(response, function (index, item) {
+                    $("#branchDropdown").append('<li><a class="branch-selector" data-id="' + item.value + '">' + item.text + '</a></li>');
+                });
+            });
+    }
+
+    $('#listModal').on('show.bs.modal', function () {
+        UpdateParticipantsList();
+    })
+
+    $("#All").on("click", function () {
+        if (systemId != null) {
+            $(this).siblings().removeClass("active");
+            $(this).addClass().addClass("active");
+            $("#systemText").text("System");
+            $("#branchText").text("Branch");
+            if (systemId != defaultSystemId) {
+                UpdateBranchList(defaultSystemId);
+            }
+            systemId = null;
+            branchId = null;
             page = 1;
             UpdateParticipantsList();
-        })
-
-        $("#clearButton").on("click", function () {
-            $("#searchText").val("");
-            if (search != "") {
-                search = "";
-                $("#searchMessage").addClass("hide");
-                page = 1;
-                UpdateParticipantsList();
-            }
-        })
-
-        $(document).on("click", ".page-button", function () {
-            if (!$(this).hasClass("disabled")) {
-                page = $(this).data("page");
-                UpdateParticipantsList();
-            }
-        });
-
-        $('#promoteModal').on('show.bs.modal', function(event) {
-            var button = $(event.relatedTarget);
-            var id = button.data('id');
-            var name = button.data('name');
-            var modal = $(this);
-            modal.find('#modal-text').text('Are you sure you wish to promote "' + name + '" to head of the household?');
-            modal.find('#PromoteId').val(id);
-        })
-
-        $('#removeModal').on('show.bs.modal', function(event) {
-            var button = $(event.relatedTarget);
-            var id = button.data('id');
-            var name = button.data('name');
-            var modal = $(this);
-            modal.find('#modal-text').text('Are you sure you wish to remove "' + name + '" from the household?');
-            modal.find('#RemoveId').val(id);
-        })
-        </text>
         }
+    });
+
+    $(".system-selector").on("click", function (e) {
+        var thisId = $(this).data("id");
+        if (systemId != thisId || branchId != null) {
+            if (systemId == null || branchId != null) {
+                var navPill = $(this).parent().parent().parent();
+                navPill.siblings().removeClass("active");
+                navPill.addClass().addClass("active");
+                if (branchId != null) {
+                    $("#branchText").text("Branch");
+                }
+            }
+            $("#systemText").text($(this).text());
+            if (systemId != thisId && (systemId != null || thisId != defaultSystemId)) {
+                UpdateBranchList(thisId);
+            }
+            systemId = thisId;
+            branchId = null;
+            page = 1;
+            UpdateParticipantsList();
+        }
+    });
+
+    $(document).on("click", ".branch-selector", function (e) {
+        var thisId = $(this).data("id");
+        if (branchId != thisId) {
+            if (branchId == null) {
+                var navPill = $(this).parent().parent().parent();
+                navPill.siblings().removeClass("active");
+                navPill.addClass().addClass("active");
+                if (systemId == null) {
+                    systemId = defaultSystemId;
+                    $("#systemText").text($(".system-selector").first().text());
+                }
+            }
+            $("#branchText").text($(this).text());
+            branchId = thisId;
+            page = 1;
+            UpdateParticipantsList();
+        }
+    });
+
+    $("#searchButton").on("click", function () {
+        search = $("#searchText").val();
+        if (search != "") {
+            $("#searchMessage").removeClass("hide");
+            $("#searchTerm").html(search);
+        }
+        else {
+            $("#searchMessage").addClass("hide");
+        }
+        page = 1;
+        UpdateParticipantsList();
+    })
+
+    $("#clearButton").on("click", function () {
+        $("#searchText").val("");
+        if (search != "") {
+            search = "";
+            $("#searchMessage").addClass("hide");
+            page = 1;
+            UpdateParticipantsList();
+        }
+    })
+
+    $(document).on("click", ".page-button", function () {
+        if (!$(this).hasClass("disabled")) {
+            page = $(this).data("page");
+            UpdateParticipantsList();
+        }
+    });
+
+    $('#promoteModal').on('show.bs.modal', function (event) {
+        var button = $(event.relatedTarget);
+        var id = button.data('id');
+        var name = button.data('name');
+        var modal = $(this);
+        modal.find('#modal-text').text('Are you sure you wish to promote "' + name + '" to head of the household?');
+        modal.find('#PromoteId').val(id);
+    })
+
+    $('#removeModal').on('show.bs.modal', function (event) {
+        var button = $(event.relatedTarget);
+        var id = button.data('id');
+        var name = button.data('name');
+        var modal = $(this);
+        modal.find('#modal-text').text('Are you sure you wish to remove "' + name + '" from the household?');
+        modal.find('#RemoveId').val(id);
+    })
+/**/
+</text>
+}
+/**/
     </script>
 }

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/UpdateGroup.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/UpdateGroup.cshtml
@@ -1,0 +1,33 @@
+﻿@model GRA.Controllers.ViewModel.MissionControl.Participants.UpdateGroupViewModel
+<div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+        <form asp-action="UpdateGroup">
+            <input asp-for="HouseholdHeadUserId" type="hidden" />
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Update group details</h3>
+                </div>
+                <div class="panel-body">
+                    <div class="form-group">
+                        <label asp-for="GroupInfo.Name" class="control-label"></label>
+                        <input asp-for="GroupInfo.Name" class="form-control" />
+                        <span asp-validation-for="GroupInfo.Name" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="GroupInfo.GroupTypeId" class="control-label"></label>
+                        <select asp-for="GroupInfo.GroupTypeId"
+                                asp-items="Model.GroupTypes"
+                                class="form-control"></select>
+                        <span asp-validation-for="GroupInfo.GroupTypeId" class="text-danger"></span>
+                    </div>
+                </div>
+                <div class="panel-footer clearfix">
+                    <div class="pull-right">
+                        <a class="btn btn-danger" href="@Url.Action("Household")">Cancel</a>
+                        <button type="submit" class="btn btn-success">Update</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/UpgradeToGroup.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/UpgradeToGroup.cshtml
@@ -1,17 +1,17 @@
-﻿@model GRA.Controllers.ViewModel.Profile.GroupUpgradeViewModel
+﻿@model GRA.Controllers.ViewModel.MissionControl.Participants.GroupUpgradeViewModel
+
 <div class="row">
     <div class="col-sm-6 col-sm-offset-3">
         <form asp-action="CreateGroup">
-            <input asp-for="AddExisting" type="hidden" />
+            <input asp-for="Id" type="hidden" />
             <div class="panel panel-default">
                 <div class="panel-heading">
                     <h3 class="panel-title">Upgrade from household to group</h3>
                 </div>
                 <div class="panel-body">
                     <p>
-                        It appears that you have more than @Model.MaximumHouseholdAllowed members in
-                        your household. We'd like you to convert your household to a group in order to
-                        add more members.
+                        In order to add more people this household must be converted to a group.
+                        Please enter a group name and select the appropriate group type.
                     </p>
                     <div class="form-group">
                         <label asp-for="GroupInfo.Name" class="control-label"></label>
@@ -23,17 +23,16 @@
                         <select asp-for="GroupInfo.GroupTypeId"
                                 asp-items="Model.GroupTypes"
                                 class="form-control"></select>
-                        <span asp-validation-for="GroupInfo.GroupTypeId" class="text-danger"></span>
+                        <span asp-validation-for="GroupInfo.GroupTypeId"
+                              class="text-danger"></span>
                     </div>
                 </div>
                 <div class="panel-footer clearfix">
                     <div class="pull-right">
-                        <button type="submit"
-                                class="btn btn-danger btn-spinner"
-                                asp-action="CancelGroupUpgrade">
+                        <a class="btn btn-danger"
+                           asp-action="Household" asp-route-id="@Model.Id">
                             <span class="buttonText">Cancel</span>
-                            <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
-                        </button>
+                        </a>
                         <button type="submit"
                                 id="Submit"
                                 name="Submit"

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/_ParticipantPartial.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/_ParticipantPartial.cshtml
@@ -8,7 +8,14 @@
             }
             <li ActiveBy routeKey="Action" value="Household">
                 <a asp-action="Household" asp-route-id="@Model.Id">
-                    Group/Household
+                    @if(Model.IsGroup)
+                    {
+                        @:Group
+                    }
+                    else
+                    {
+                        @:Household
+                    }
                     @if (Model.HouseholdCount > 0)
                     {
                         <span class="label label-default label-as-badge">@(Model.HouseholdCount + 1)</span>

--- a/src/GRA.Web/Areas/MissionControl/Views/Participants/_ParticipantPartial.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Participants/_ParticipantPartial.cshtml
@@ -8,7 +8,7 @@
             }
             <li ActiveBy routeKey="Action" value="Household">
                 <a asp-action="Household" asp-route-id="@Model.Id">
-                    Household
+                    Group/Household
                     @if (Model.HouseholdCount > 0)
                     {
                         <span class="label label-default label-as-badge">@(Model.HouseholdCount + 1)</span>

--- a/src/GRA.Web/Areas/MissionControl/Views/Programs/Detail.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Programs/Detail.cshtml
@@ -94,11 +94,11 @@
                 <div class="col-xs-12 col-sm-4 col-md-3">
                     @if (!string.IsNullOrWhiteSpace(Model.BadgePath))
                     {
-                        <label class="control-label">Edit badge image</label>
+                        <label class="control-label">Edit sign-up badge</label>
                     }
                     else
                     {
-                        <label class="control-label">Add a badge</label>
+                        <label class="control-label">Add a sign-up badge</label>
                     }
 
                     @if (!string.IsNullOrWhiteSpace(Model.BadgePath))

--- a/src/GRA.Web/Areas/MissionControl/Views/Shared/_Layout.cshtml
+++ b/src/GRA.Web/Areas/MissionControl/Views/Shared/_Layout.cshtml
@@ -129,40 +129,44 @@
                             <ul class="dropdown-menu">
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageCategories.ToString()))
                                 {
-                                    <li><a asp-controller="Categories" asp-action="Index">Categories</a></li>
+                                    <li><a asp-controller="Categories" asp-action="Index">Category management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageDashboardContent.ToString()))
                                 {
-                                    <li><a asp-controller="Dashboard" asp-action="Index">Dashboard</a></li>
+                                    <li><a asp-controller="Dashboard" asp-action="Index">Dashboard Content management</a></li>
+                                }
+                                @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageGroupTypes.ToString()))
+                                {
+                                    <li><a asp-controller="GroupTypes" asp-action="Index">Group Type management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ViewUnpublishedPages.ToString()))
                                 {
-                                    <li><a asp-controller="Pages" asp-action="Index">Pages</a></li>
+                                    <li><a asp-controller="Pages" asp-action="Index">Page management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManagePrograms.ToString()))
                                 {
-                                    <li><a asp-controller="Programs" asp-action="Index">Programs</a></li>
+                                    <li><a asp-controller="Programs" asp-action="Index">Program management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageQuestionnaires.ToString()))
                                 {
-                                    <li><a asp-controller="Questionnaires" asp-action="Index">Questionnaires</a></li>
+                                    <li><a asp-controller="Questionnaires" asp-action="Index">Questionnaire management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageSchools.ToString()))
                                 {
-                                    <li><a asp-controller="Schools" asp-action="Index">Schools</a></li>
+                                    <li><a asp-controller="Schools" asp-action="Index">School management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageSystems.ToString()))
                                 {
-                                    <li><a asp-controller="Systems" asp-action="Index">Systems/Branches</a></li>
+                                    <li><a asp-controller="Systems" asp-action="Index">System &amp; branch management</a></li>
                                 }
                                 @if (Context.User.HasClaim(GRA.ClaimType.Permission, GRA.Domain.Model.Permission.ManageVendorCodes.ToString()))
                                 {
-                                    <li><a asp-controller="VendorCodes" asp-action="ImportStatus">Vendor code status</a></li>
+                                    <li><a asp-controller="VendorCodes" asp-action="ImportStatus">Vendor code management</a></li>
                                 }
                                 <li>
                                     <a asp-controller="SystemInformation" asp-action="Index">
                                         <span class="fa fa-info-circle"></span>
-                                        System Info
+                                        System information
                                     </a>
                                 </li>
                             </ul>
@@ -183,7 +187,7 @@
         </noscript>
 
         @if (ViewData.ContainsKey(GRA.Controllers.ViewDataKey.TitleHtml)
-               && ViewData[GRA.Controllers.ViewDataKey.TitleHtml] != null)
+           && ViewData[GRA.Controllers.ViewDataKey.TitleHtml] != null)
         {
             <div class="row">
                 <div class="col-xs-12">

--- a/src/GRA.Web/Startup.cs
+++ b/src/GRA.Web/Startup.cs
@@ -234,6 +234,7 @@ namespace GRA.Web
             services.AddScoped<EmailService>();
             services.AddScoped<EventImportService>();
             services.AddScoped<EventService>();
+            services.AddScoped<GroupTypeService>();
             services.AddScoped<MailService>();
             services.AddScoped<PageService>();
             services.AddScoped<PointTranslationService>();
@@ -308,6 +309,8 @@ namespace GRA.Web
             services.AddScoped<Domain.Repository.IEmailReminderRepository, Data.Repository.EmailReminderRepository>();
             services.AddScoped<Domain.Repository.IEnteredSchoolRepository, Data.Repository.EnteredSchoolRepository>();
             services.AddScoped<Domain.Repository.IEventRepository, Data.Repository.EventRepository>();
+            services.AddScoped<Domain.Repository.IGroupInfoRepository, Data.Repository.GroupInfoRepository>();
+            services.AddScoped<Domain.Repository.IGroupTypeRepository, Data.Repository.GroupTypeRepository>();
             services.AddScoped<Domain.Repository.ILocationRepository, Data.Repository.LocationRepository>();
             services.AddScoped<Domain.Repository.IMailRepository, Data.Repository.MailRepository>();
             services.AddScoped<Domain.Repository.INotificationRepository, Data.Repository.NotificationRepository>();

--- a/src/GRA.Web/Views/Profile/AddExistingParticipant.cshtml
+++ b/src/GRA.Web/Views/Profile/AddExistingParticipant.cshtml
@@ -15,7 +15,14 @@
                             <div class="row row-spacing">
                                 <div class="col-xs-12">
                                     <p>
-                                        Add an existing participant into your household, if that participant is the head of a household their household members will be moved into your household as well.
+                                        Add an existing participant into your
+                                        @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle].ToString().ToLower(), if
+                                        that participant is the head of a
+                                        @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle].ToString().ToLower() their
+                                        @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle].ToString().ToLower()
+                                        members will be moved into your
+                                        @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle].ToString().ToLower() as
+                                        well.
                                     </p>
                                 </div>
                             </div>
@@ -39,7 +46,7 @@
                     </div>
 
                     <div class="form-group">
-                        <a asp-action="Household" class="btn btn-default">Return to Household</a>
+                        <a asp-action="Household" class="btn btn-default">Return to @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle]</a>
                         <button type="submit" id="Submit" name="Submit" value="Submit" class="btn btn-primary btn-spinner">
                             <span class="buttonText">Add Participant</span>
                             <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>

--- a/src/GRA.Web/Views/Profile/GroupDetails.cshtml
+++ b/src/GRA.Web/Views/Profile/GroupDetails.cshtml
@@ -1,0 +1,29 @@
+﻿@model GRA.Domain.Model.GroupInfo
+<div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+        <form asp-action="GroupDetails">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Update group details</h3>
+                </div>
+                <div class="panel-body">
+                    <div class="form-group">
+                        <label asp-for="Name" class="control-label"></label>
+                        <input asp-for="Name" class="form-control" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="GroupTypeName" class="control-label"></label>
+                        <input asp-for="GroupTypeName" class="form-control" readonly disabled />
+                    </div>
+                </div>
+                <div class="panel-footer clearfix">
+                    <div class="pull-right">
+                        <a class="btn btn-danger" href="@Url.Action("Household")">Cancel</a>
+                        <button type="submit" class="btn btn-success">Update</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/GRA.Web/Views/Profile/GroupUpgrade.cshtml
+++ b/src/GRA.Web/Views/Profile/GroupUpgrade.cshtml
@@ -1,0 +1,38 @@
+﻿@model GRA.Controllers.ViewModel.Profile.GroupUpgradeViewModel
+<div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+        <form asp-action="CreateGroup">
+            <input asp-for="AddExisting" type="hidden" />
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Upgrade from household to group</h3>
+                </div>
+                <div class="panel-body">
+                    <p>
+                        It appears that you have more than @Model.MaximumHouseholdAllowed members in
+                        your household. We'd like you to convert your household to a group in order to
+                        add more members.
+                    </p>
+                    <div class="form-group">
+                        <label asp-for="GroupInfo.Name" class="control-label"></label>
+                        <input asp-for="GroupInfo.Name" class="form-control" />
+                        <span asp-validation-for="GroupInfo.Name" class="text-danger"></span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="GroupInfo.GroupTypeId" class="control-label"></label>
+                        <select asp-for="GroupInfo.GroupTypeId"
+                                asp-items="Model.GroupTypes"
+                                class="form-control"></select>
+                        <span asp-validation-for="GroupInfo.GroupTypeId" class="text-danger"></span>
+                    </div>
+                </div>
+                <div class="panel-footer clearfix">
+                    <div class="pull-right">
+                        <a class="btn btn-danger" href="@Url.Action("Household")">Cancel</a>
+                        <button type="submit" class="btn btn-success">Upgrade to group</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/GRA.Web/Views/Profile/GroupUpgrade.cshtml
+++ b/src/GRA.Web/Views/Profile/GroupUpgrade.cshtml
@@ -28,8 +28,17 @@
                 </div>
                 <div class="panel-footer clearfix">
                     <div class="pull-right">
+                        <button type="submit" 
+                                class="btn btn-danger btn-spinner"
+                                asp-action="CancelGroupUpgrade">
+                            <span class="buttonText">Cancel</span>
+                            <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
+                        </button>
                         <a class="btn btn-danger" href="@Url.Action("Household")">Cancel</a>
-                        <button type="submit" class="btn btn-success">Upgrade to group</button>
+                        <button type="submit" id="Submit" name="Submit" value="Submit" class="btn btn-primary btn-spinner">
+                            <span class="buttonText">Upgrade to group</span>
+                            <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/src/GRA.Web/Views/Profile/Household.cshtml
+++ b/src/GRA.Web/Views/Profile/Household.cshtml
@@ -38,8 +38,19 @@
                 <span class="lead">My Profile</span>
             </div>
             <div class="panel-body">
-
                 @Html.Partial("_ProfilePartial")
+
+                @if (!string.IsNullOrEmpty(Model.GroupName))
+                {
+                    @if (Model.GroupLeader)
+                    {
+                        @:You are leader of the group: <a href="@Url.Action("GroupDetails")"><strong>@Model.GroupName</strong></a>
+                    }
+                    else
+                    {
+                        @:You are in the group: <strong>@Model.GroupName</strong>
+                    }
+                }
 
                 <div class="row" style="padding: 10px 0;">
                     <div class="col-xs-12">
@@ -47,8 +58,8 @@
                         {
                             if (Model.CanEditHousehold)
                             {
-                                <div class="alert alert-warning">Click below to create a household</div>
-                                <a asp-action="AddHouseholdMember" class="btn btn-default">Add Household Member</a>
+                                <div class="alert alert-warning">Click below to create a @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle].ToString().ToLower()</div>
+                                <a asp-action="AddHouseholdMember" class="btn btn-default">Add @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle] Member</a>
                                 <a asp-action="AddExistingParticipant" class="btn btn-default">Add Existing Participant</a>
                             }
                             else
@@ -481,8 +492,8 @@
                             </form>
                             @if (Model.AuthUserIsHead && Model.CanEditHousehold)
                             {
-                                <a asp-action="AddHouseholdMember" class="btn btn-default">Add Household Member</a>
-                                <a asp-action="AddExistingParticipant" class="btn btn-default">Add Existing Participant</a>
+                                <a asp-action="AddHouseholdMember" class="btn btn-default">Register new @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle] Member</a>
+                                <a asp-action="AddExistingParticipant" class="btn btn-default">Add existing participant to your @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle]</a>
                             }
                         }
                     </div>

--- a/src/GRA.Web/Views/Profile/HouseholdAdd.cshtml
+++ b/src/GRA.Web/Views/Profile/HouseholdAdd.cshtml
@@ -4,7 +4,7 @@
     <div class="col-xs-12 col-sm-10 col-sm-offset-1">
         <div class="panel panel-default">
             <div class="panel-heading">
-                <span class="lead">Add Household Member</span>
+                <span class="lead">Add @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle] Member</span>
             </div>
             <div class="panel-body">
 
@@ -157,7 +157,7 @@
                     </div>
 
                     <div class="form-group">
-                        <a asp-action="Household" class="btn btn-default">Return to Household</a>
+                        <a asp-action="Household" class="btn btn-default">Return to @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle]</a>
                         <button type="submit" id="Submit" name="Submit" value="Submit" class="btn btn-primary btn-spinner">
                             <span class="buttonText">Add Member</span>
                             <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>

--- a/src/GRA.Web/Views/Profile/HouseholdRegisterMember.cshtml
+++ b/src/GRA.Web/Views/Profile/HouseholdRegisterMember.cshtml
@@ -4,7 +4,7 @@
     <div class="col-xs-12 col-sm-10 col-sm-offset-1">
         <div class="panel panel-default">
             <div class="panel-heading">
-                <span class="lead">Register Household Member</span>
+                <span class="lead">Register @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle] Member</span>
             </div>
             <div class="panel-body">
                 <form asp-controller="Profile" asp-action="RegisterHouseholdMember" method="post" role="form">
@@ -42,7 +42,7 @@
                     </div>
 
                     <div class="form-group">
-                        <a asp-action="Household" class="btn btn-default">Return to Household</a>
+                        <a asp-action="Household" class="btn btn-default">Return to @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle]</a>
                         <button type="submit" id="Submit" name="Submit" value="Submit" class="btn btn-primary btn-spinner">
                             <span class="buttonText">Register Member</span>
                             <span class="fa fa-spinner fa-pulse fa-lg fa-fw hidden"></span>

--- a/src/GRA.Web/Views/Profile/_ProfilePartial.cshtml
+++ b/src/GRA.Web/Views/Profile/_ProfilePartial.cshtml
@@ -4,7 +4,7 @@
             <li ActiveBy routeKey="Action" value="Index"><a asp-action="Index">Details</a></li>
             <li ActiveBy routeKey="Action" value="Household">
                 <a asp-action="Household">
-                    Household
+                    @Context.Items[GRA.Controllers.ItemKey.HouseholdTitle]
                     @if (Model.HouseholdCount > 0)
                     {
                         <span class="label label-default label-as-badge">@(Model.HouseholdCount + 1)</span>

--- a/src/GRA/SiteSettingKey.cs
+++ b/src/GRA/SiteSettingKey.cs
@@ -31,6 +31,10 @@ namespace GRA
             // If this is set (i.e. not null) do not allow users to change their system/branch after
             // joining
             public const string RestrictChangingSystemBranch = "Users.RestrictChangingSystemBranch";
+
+            // If this is set to an integer, when the household count exceeds this number the
+            // household head will be forced to enter a group name and select a group type.
+            public const string MaximumHouseholdSizeBeforeGroup = "Users.MaximumHouseholdSizeBeforeGroup";
         }
     }
 }


### PR DESCRIPTION
- Add a system setting ("Users.MaximumHouseholdSizeBeforeGroup") for the maximum household size before conversion to a group
- Add group and group type management and enforcement
- Add site setting format "Integer"
- Move site setting convenience methods to SiteLookupService
- Refactor out an abstract ParticipantPartialViewModel
- Better describe options in the system configuration menu
- Allow Mission Control editing of group names and selection of group type