### PR TITLE
Trim category name on add/edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Change "Edit" buttons to "Save"
 - Rename GetSiteStageAsync to GetSiteStage since it wasn't async
 - Issue with duplicate claims throwing an exception unnecessarily
-- Read a book option drawing criteria option
+- Read a book drawing criteria option
 
 ### Removed
 - "Is achiever" property from Users

--- a/src/GRA.Domain.Service/CategoryService.cs
+++ b/src/GRA.Domain.Service/CategoryService.cs
@@ -42,6 +42,8 @@ namespace GRA.Domain.Service
         public async Task<Category> AddAsync(Category category)
         {
             VerifyManagementPermission();
+            category.Name = category.Name.Trim();
+            category.Description = category.Description.Trim();
             category.SiteId = GetCurrentSiteId();
             if (string.IsNullOrWhiteSpace(category.Color))
             {
@@ -54,6 +56,8 @@ namespace GRA.Domain.Service
         {
             VerifyManagementPermission();
             var current = await _categoryRepository.GetByIdAsync(category.Id);
+            category.Name = category.Name.Trim();
+            category.Description = category.Description.Trim();
             category.SiteId = current.SiteId;
             return await _categoryRepository.UpdateSaveAsync(GetClaimId(ClaimType.UserId), category);
         }


### PR DESCRIPTION
- Fix #487 - Category names don't have leading and trailing spaces trimmed upon add or edit